### PR TITLE
set wpsWorkDirIsRWorkDir to false

### DIFF
--- a/52n-wps-r/src/main/java/org/n52/wps/server/r/GenericRProcess.java
+++ b/52n-wps-r/src/main/java/org/n52/wps/server/r/GenericRProcess.java
@@ -476,6 +476,7 @@ public class GenericRProcess extends AbstractObservableAlgorithm {
                 // setting the R working directory relative to default R directory
                 // R starts from a work directory dependent on the behaviour and configuration of the R/Rserve
                 // installation
+                this.wpsWorkDirIsRWorkDir = false;
                 String randomFolderName = "wps4r-r-workdir-" + UUID.randomUUID().toString().substring(0, 8);
                 rCon.eval("dir.create(\"" + randomFolderName + "\")"); // quotation marks!
                 result = rCon.eval("setwd(\"" + randomFolderName + "\")"); // don't forget the escaped


### PR DESCRIPTION
This seems to not get set when RServe is remote.  I think this could either start as false and be set to true if it is localhost, or set it to false in this case.
