### PR TITLE
remove jcommon as direct dependency, increase jfreechart version

### DIFF
--- a/52n-wps-sextante/pom.xml
+++ b/52n-wps-sextante/pom.xml
@@ -46,10 +46,6 @@
 			<artifactId>sextante_gt27_bindings</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>jfree</groupId>
-			<artifactId>jcommon</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.beanshell</groupId>
 			<artifactId>bsh</artifactId>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -744,17 +744,6 @@
 				<version>1.0.1</version>
 			</dependency>
 			<dependency>
-				<groupId>jfree</groupId>
-				<artifactId>jcommon</artifactId>
-				<version>1.0.14</version>
-				<exclusions>
-					<exclusion>
-						<artifactId>gnujaxp</artifactId>
-						<groupId>gnujaxp</groupId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
 				<groupId>org.beanshell</groupId>
 				<artifactId>bsh</artifactId>
 				<version>2.0b4</version>
@@ -762,13 +751,7 @@
 			<dependency>
 				<groupId>jfree</groupId>
 				<artifactId>jfreechart</artifactId>
-				<version>1.0.11</version>
-				<exclusions>
-					<exclusion>
-						<artifactId>gnujaxp</artifactId>
-						<groupId>gnujaxp</groupId>
-					</exclusion>
-				</exclusions>
+				<version>1.0.13</version>
 			</dependency>
 			<dependency>
 				<groupId>trove</groupId>


### PR DESCRIPTION
this removes the gnujaxp transient dep without explicit exclusion.
