### PR TITLE
Move R eval and log commands to after successful login

### DIFF
--- a/52n-wps-r/src/main/java/org/n52/wps/server/r/util/RConnector.java
+++ b/52n-wps-r/src/main/java/org/n52/wps/server/r/util/RConnector.java
@@ -48,6 +48,16 @@ public class RConnector {
         if (con != null && con.needLogin())
             con.login(user, password);
 
+        RLogger.log(con, "New connection from WPS4R");
+
+        REXP info = con.eval("capture.output(sessionInfo())");
+        try {
+            log.debug("NEW CONNECTION >>> sessionInfo:\n" + Arrays.deepToString(info.asStrings()));
+        }
+        catch (REXPMismatchException e) {
+            log.warn("Error creating session info.", e);
+        }
+        
         return con;
     }
 
@@ -112,15 +122,7 @@ public class RConnector {
 
         RConnection con;
         con = new RConnection(host, port);
-        RLogger.log(con, "New connection from WPS4R");
 
-        REXP info = con.eval("capture.output(sessionInfo())");
-        try {
-            log.debug("NEW CONNECTION >>> sessionInfo:\n" + Arrays.deepToString(info.asStrings()));
-        }
-        catch (REXPMismatchException e) {
-            log.warn("Error creating session info.", e);
-        }
         return con;
     }
 


### PR DESCRIPTION
Password logins were failing because the con.login must be the first command to reach Rserve after a connection is established.  I moved the post login actions to the method that is called from R_Config.  Because of this, someone getting a connection by calling the other getNewConnection method would not have this behavior.  That method should maybe be private to avoid this confusion.
