### PR TITLE
change constructor of LiteralBooleanBinding

### DIFF
--- a/52n-wps-io/src/main/java/org/n52/wps/io/data/binding/literal/LiteralBooleanBinding.java
+++ b/52n-wps-io/src/main/java/org/n52/wps/io/data/binding/literal/LiteralBooleanBinding.java
@@ -8,8 +8,8 @@ public class LiteralBooleanBinding extends AbstractLiteralDataBinding {
 	 */
 	private static final long serialVersionUID = -8476435383089241416L;
 	private transient boolean payload;
-	
-	public LiteralBooleanBinding(boolean payload){
+		
+	public LiteralBooleanBinding(Boolean payload){
 		this.payload = payload;
 	}
 	


### PR DESCRIPTION
This fixes an issue with AbstractAnnotatedAlgorithm. The LiteralBooleanBinding could not be mapped to the return type of an annotated method as the constructor was not using the wrapped simple type.
