### PR TITLE
 add check to method for updating the response if the value is null.

### DIFF
--- a/52n-wps-server/src/main/java/org/n52/wps/server/response/OutputDataItem.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/response/OutputDataItem.java
@@ -50,11 +50,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-
 import org.n52.wps.io.BasicXMLTypeFactory;
 import org.n52.wps.io.IOHandler;
 import org.n52.wps.io.data.IBBOXData;
@@ -63,6 +58,10 @@ import org.n52.wps.io.data.binding.literal.AbstractLiteralDataBinding;
 import org.n52.wps.server.ExceptionReport;
 import org.n52.wps.server.database.DatabaseFactory;
 import org.n52.wps.server.database.IDatabase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 import com.google.common.primitives.Doubles;
 
@@ -175,21 +174,29 @@ public class OutputDataItem extends ResponseData {
 		}
 	}
 
-	public void updateResponseForLiteralData(ExecuteResponseDocument res, String dataTypeReference){
-		OutputDataType output = prepareOutput(res);
-		String processValue = BasicXMLTypeFactory.getStringRepresentation(dataTypeReference, obj);
-		LiteralDataType literalData = output.addNewData().addNewLiteralData();
-		if (dataTypeReference != null) {
-			literalData.setDataType(dataTypeReference);
-		}
-	    literalData.setStringValue(processValue);
-		if(obj instanceof AbstractLiteralDataBinding){
-			String uom = ((AbstractLiteralDataBinding)obj).getUnitOfMeasurement();
-			if(uom != null && !uom.equals("")){
-				literalData.setUom(uom);
-			}
-		}
-	}
+    public void updateResponseForLiteralData(ExecuteResponseDocument res, String dataTypeReference) {
+        OutputDataType output = prepareOutput(res);
+        String processValue = null;
+        if (obj == null) {
+            LOGGER.warn("Literal data object is 'null', cannot add it to response: " + output.xmlText()
+                    + " -- data type: " + dataTypeReference);
+            processValue = "ERROR: OBJECT IS NULL";
+        }
+        else {
+            processValue = BasicXMLTypeFactory.getStringRepresentation(dataTypeReference, obj);
+        }
+        LiteralDataType literalData = output.addNewData().addNewLiteralData();
+        if (dataTypeReference != null) {
+            literalData.setDataType(dataTypeReference);
+        }
+        literalData.setStringValue(processValue);
+        if (obj instanceof AbstractLiteralDataBinding) {
+            String uom = ((AbstractLiteralDataBinding) obj).getUnitOfMeasurement();
+            if (uom != null && !uom.equals("")) {
+                literalData.setUom(uom);
+            }
+        }
+    }
 
 	public void updateResponseAsReference(ExecuteResponseDocument res, String reqID, String mimeType) throws ExceptionReport {
 		prepareGenerator();


### PR DESCRIPTION
If it was null (e.g. in a not set variable of an annotated process) this method threw a nullpointerexception and the whole process failed. An alternative would be to log the error and not add the output at all, but since this is literal data Imho an error message could be OK.

Does the spec. say something about failing if parts of a process failed?
