### PR TITLE
adjust return type of getPayload. now works with annotation parsing

### DIFF
--- a/52n-wps-io-impl/src/main/java/org/n52/wps/io/data/binding/complex/PlainStringBinding.java
+++ b/52n-wps-io-impl/src/main/java/org/n52/wps/io/data/binding/complex/PlainStringBinding.java
@@ -39,7 +39,7 @@ public class PlainStringBinding implements IComplexData{
 		payload = string;
 	}
 
-	public Object getPayload() {
+	public String getPayload() {
 		return payload;
 	}
 


### PR DESCRIPTION
the annotation parser could not create ComplexInputs from PlainStringBinding as Object could not be cast to String.