### PR TITLE
Make Repository Manager manageble by IoC

### DIFF
--- a/52n-wps-algorithm-geotools/src/test/java/org/n52/wps/server/algorithm/SimpleBufferAlgorithmTest.java
+++ b/52n-wps-algorithm-geotools/src/test/java/org/n52/wps/server/algorithm/SimpleBufferAlgorithmTest.java
@@ -87,8 +87,6 @@ public class SimpleBufferAlgorithmTest extends AbstractITClass{
 
     @Before
     public void setUp() {
-		MockMvcBuilders.webAppContextSetup(this.wac).build();
-		WPSConfig.getInstance().setConfigurationManager(this.wac.getBean(ConfigurationManager.class));
     }
 
     @After

--- a/52n-wps-algorithm/src/main/java/org/n52/wps/server/ServiceLoaderAlgorithmRepository.java
+++ b/52n-wps-algorithm/src/main/java/org/n52/wps/server/ServiceLoaderAlgorithmRepository.java
@@ -34,20 +34,20 @@ public class ServiceLoaderAlgorithmRepository implements IAlgorithmRepository {
 	public ServiceLoaderAlgorithmRepository() {
 		this.currentAlgorithms = loadAlgorithms();
 	}
-	
+
 	private Map<String, Class<? extends IAlgorithm>> loadAlgorithms() {
 		Map<String, Class<? extends IAlgorithm>> result = new HashMap<String, Class<? extends IAlgorithm>>();
 		ServiceLoader<IAlgorithm> loader = ServiceLoader.load(IAlgorithm.class);
-		
+
 		for (IAlgorithm ia : loader) {
 			logger.debug("Adding algorithm with identifier {} and class {}",
 					ia.getWellKnownName(), ia.getClass().getCanonicalName());
 			result.put(ia.getWellKnownName(), ia.getClass());
 		}
-		
+
 		return result;
 	}
-	
+
 	@Override
 	public Collection<String> getAlgorithmNames() {
 		return this.currentAlgorithms.keySet();

--- a/52n-wps-algorithm/src/test/java/org/n52/wps/server/AbstractSelfDescribingAlgorithmTest.java
+++ b/52n-wps-algorithm/src/test/java/org/n52/wps/server/AbstractSelfDescribingAlgorithmTest.java
@@ -33,14 +33,12 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
  * @author tkunicki
  */
 public class AbstractSelfDescribingAlgorithmTest extends AbstractITClass {
-    
+
     public AbstractSelfDescribingAlgorithmTest() {
     }
 
     @Before
     public void setUp() throws Exception {
-		MockMvcBuilders.webAppContextSetup(this.wac).build();
-		WPSConfig.getInstance().setConfigurationManager(this.wac.getBean(ConfigurationManager.class));
     }
 
     @Test

--- a/52n-wps-client-lib/src/test/java/org/n52/wps/client/test/ExecuteRequestBuilderTest.java
+++ b/52n-wps-client-lib/src/test/java/org/n52/wps/client/test/ExecuteRequestBuilderTest.java
@@ -60,28 +60,26 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 public class ExecuteRequestBuilderTest extends AbstractITClass{
 
-	private ProcessDescription processDescription;	
-	private ProcessDescriptionType processDescriptionType;	
+	private ProcessDescription processDescription;
+	private ProcessDescriptionType processDescriptionType;
 	private String inputID;
 	private String outputID;
 	private String url = "http://xyz.test.data";
 	private String complexDataString = "testString";
-	
+
 	@Before
 	public void setUp(){
-		MockMvcBuilders.webAppContextSetup(this.wac).build();
-		WPSConfig.getInstance().setConfigurationManager(this.wac.getBean(ConfigurationManager.class));	
 		processDescription = new MultiReferenceBinaryInputAlgorithm().getDescription();
-		processDescriptionType = ((ProcessDescriptionType)processDescription.getProcessDescriptionType(WPSConfig.VERSION_100));	
+		processDescriptionType = ((ProcessDescriptionType)processDescription.getProcessDescriptionType(WPSConfig.VERSION_100));
 		inputID = processDescriptionType.getDataInputs().getInputArray(0).getIdentifier().getStringValue();
 		outputID = processDescriptionType.getProcessOutputs().getOutputArray(0).getIdentifier().getStringValue();
 	}
-	
+
     @Test
     public void addComplexDataInputByReference() {
 
         ExecuteRequestBuilder executeRequestBuilder = new ExecuteRequestBuilder(processDescriptionType);
-    	
+
     	addTestDataByReference(executeRequestBuilder);
 
         ExecuteDocument request = executeRequestBuilder.getExecute();
@@ -90,151 +88,151 @@ public class ExecuteRequestBuilderTest extends AbstractITClass{
         Assert.assertThat("generated doc contains input url", request.toString(), containsString(url));
         Assert.assertThat("document is valid", request.validate(), is(true));
     }
-    
+
     @Test
     public void addComplexDataInputString() {
-    	
+
     	ExecuteRequestBuilder executeRequestBuilder = new ExecuteRequestBuilder(processDescriptionType);
-    	
+
     	addTestDataString(executeRequestBuilder);
-    	
+
     	ExecuteDocument request = executeRequestBuilder.getExecute();
-    	
+
     	Assert.assertThat("generated doc contains input id", request.toString(), containsString(inputID));
     	Assert.assertThat("generated doc contains input string", request.toString(), containsString(complexDataString));
     	Assert.assertThat("document is valid", request.validate(), is(true));
     }
-    
+
     @Test
     public void setSupportedMimeTypeForOutput(){
         ExecuteRequestBuilder executeRequestBuilder = new ExecuteRequestBuilder(processDescriptionType);
-    	
+
     	addTestDataByReference(executeRequestBuilder);
-        
+
         String mimeType = getMimeType(processDescriptionType, false);
-        
+
         executeRequestBuilder.setMimeTypeForOutput(mimeType, outputID);
-        
+
         ExecuteDocument request = executeRequestBuilder.getExecute();
-        
+
         checkOutputIdentifier(request.getExecute(), outputID);
         checkOutputMimeType(request.getExecute(), mimeType);
         Assert.assertThat("document is valid", request.validate(), is(true));
-    	
+
     }
-    
+
     @Test
     public void setDefaultMimeTypeForOutput(){
     	ExecuteRequestBuilder executeRequestBuilder = new ExecuteRequestBuilder(processDescriptionType);
-    	
+
     	addTestDataByReference(executeRequestBuilder);
-    	
+
     	String mimeType = getMimeType(processDescriptionType, true);
-    			
+
     	ExecuteDocument request = executeRequestBuilder.getExecute();
-        
+
         executeRequestBuilder.setMimeTypeForOutput(mimeType, outputID);
-    	
+
         checkOutputIdentifier(request.getExecute(), outputID);
         checkOutputMimeType(request.getExecute(), mimeType);
     	Assert.assertThat("document is valid", request.validate(), is(true));
-    	
+
     }
-    
+
     private void addTestDataByReference(ExecuteRequestBuilder executeRequestBuilder){
-        
+
     	InputType inputType = InputType.Factory.newInstance();
 
         inputType.addNewIdentifier().setStringValue(inputID);
         inputType.addNewReference().setHref(url);
 
         executeRequestBuilder.addComplexData(inputType);
-    	
+
     }
-    
+
     private void addTestDataString(ExecuteRequestBuilder executeRequestBuilder){
-    	
+
     	try {
 			executeRequestBuilder.addComplexData(inputID, complexDataString, "", "", "text/plain");
 		} catch (WPSClientException e) {
 			e.printStackTrace();
 		}
-    	
+
     }
-    
+
     private String getMimeType(ProcessDescriptionType processDescriptionType, boolean isGetDefaultMimeType){
-    	
+
     	String result = "";
-    	
+
     	ProcessOutputs processOutputs = processDescriptionType.getProcessOutputs();
-    	
+
     	assertNotNull(processOutputs);
-    	
+
     	OutputDescriptionType outputDescriptionType = processOutputs.getOutputArray(0);
-    	
+
     	assertNotNull(outputDescriptionType);
-    	
+
     	SupportedComplexDataType complexDataType = outputDescriptionType.getComplexOutput();
-    	
+
     	assertNotNull(complexDataType);
-    	
+
     	if(isGetDefaultMimeType){
     		ComplexDataCombinationType defaultFormat = complexDataType.getDefault();
-    		
+
     		assertNotNull(defaultFormat);
-    		
+
     		ComplexDataDescriptionType format = defaultFormat.getFormat();
-    		
+
     		assertNotNull(format);
-    		
-    		result = format.getMimeType();    		
+
+    		result = format.getMimeType();
     	}else{
     		ComplexDataCombinationsType supportedFormats = complexDataType.getSupported();
-    		
+
     		assertNotNull(supportedFormats);
-    		
+
     		ComplexDataDescriptionType format = supportedFormats.getFormatArray(0);
-    		
+
     		assertNotNull(format);
-    		
-    		result = format.getMimeType();   
+
+    		result = format.getMimeType();
     	}
-    	
+
     	return result;
     }
 
     private void checkOutputMimeType(Execute execute, String mimeType){
-    	
+
     	DocumentOutputDefinitionType outputDefinitionType = getOutputDefinitionType(execute);
-    	
-    	assertTrue(outputDefinitionType.getMimeType() != null && outputDefinitionType.getMimeType().equals(mimeType)); 
-    	
+
+    	assertTrue(outputDefinitionType.getMimeType() != null && outputDefinitionType.getMimeType().equals(mimeType));
+
     }
-    
+
     private void checkOutputIdentifier(Execute execute, String identifier){
-    	
+
     	DocumentOutputDefinitionType outputDefinitionType = getOutputDefinitionType(execute);
-    	
-    	assertTrue(outputDefinitionType.getIdentifier() != null && outputDefinitionType.getIdentifier().getStringValue().equals(identifier)); 
-    	
+
+    	assertTrue(outputDefinitionType.getIdentifier() != null && outputDefinitionType.getIdentifier().getStringValue().equals(identifier));
+
     }
-    
+
     private DocumentOutputDefinitionType getOutputDefinitionType(Execute execute){
-    	
+
     	ResponseFormType responseFormType = execute.getResponseForm();
-    	
+
     	assertNotNull(responseFormType);
-    	
+
     	ResponseDocumentType responseDocumentType = responseFormType.getResponseDocument();
-    	
+
     	assertNotNull(responseDocumentType);
-    	
+
     	DocumentOutputDefinitionType outputDefinitionType = responseDocumentType.getOutputArray(0);
-    	
-    	assertNotNull(outputDefinitionType);  
-    	
+
+    	assertNotNull(outputDefinitionType);
+
     	return outputDefinitionType;
-    	
+
     }
-    
+
 }

--- a/52n-wps-commons/src/main/java/org/n52/wps/commons/WPSConfig.java
+++ b/52n-wps-commons/src/main/java/org/n52/wps/commons/WPSConfig.java
@@ -41,7 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * 
+ *
  * @author Benjamin Pross, Daniel Nüst
  *
  */
@@ -66,19 +66,20 @@ public class WPSConfig implements Serializable {
 	public static final String VERSION_100 = "1.0.0";
 	public static final String VERSION_200 = "2.0.0";
 	public static final List<String> SUPPORTED_VERSIONS = Arrays.asList(new String[]{VERSION_100, VERSION_200});
-	
+
 	public static final String JOB_CONTROL_OPTION_SYNC_EXECUTE = "sync-execute";
 	public static final String JOB_CONTROL_OPTION_ASYNC_EXECUTE = "async-execute";
-	
+
 	public static final String JOB_CONTROL_OPTIONS_SEPARATOR = " ";
-	
+
 	public static final String OUTPUT_TRANSMISSION_VALUE = "value";
 	public static final String OUTPUT_TRANSMISSION_REFERENCE = "reference";
-	
+
 	public static final String OUTPUT_TRANSMISSIONS_SEPARATOR = " ";
-    
+
 	private ConfigurationManager configurationManager;
-    private Server serverConfigurationModule;	
+    
+    private Server serverConfigurationModule;
 
 	public Server getServerConfigurationModule() {
 
@@ -176,46 +177,46 @@ public class WPSConfig implements Serializable {
     }
 
 	public List<? extends ConfigurationEntry<?>> getConfigurationEntriesForGeneratorClass(
-			String name) {	
+			String name) {
 		ConfigurationModule module = getConfigurationModuleForClass(name, ConfigurationCategory.GENERATOR);
 		return  (module == null) ? new ArrayList<ConfigurationEntry<?>>() : module.getConfigurationEntries();
 	}
 
-	public List<FormatEntry> getFormatEntriesForGeneratorClass(String name) {	
+	public List<FormatEntry> getFormatEntriesForGeneratorClass(String name) {
 		ConfigurationModule module = getConfigurationModuleForClass(name, ConfigurationCategory.GENERATOR);
 		return  (module == null) ? new ArrayList<FormatEntry>() : module.getFormatEntries();
 	}
 
 	public List<? extends ConfigurationEntry<?>> getConfigurationEntriesForParserClass(
-			String name) {	
+			String name) {
 		ConfigurationModule module = getConfigurationModuleForClass(name, ConfigurationCategory.PARSER);
 		return  (module == null) ? new ArrayList<ConfigurationEntry<?>>() : module.getConfigurationEntries();
 	}
 
-	public List<FormatEntry> getFormatEntriesForParserClass(String name) {	
+	public List<FormatEntry> getFormatEntriesForParserClass(String name) {
 		ConfigurationModule module = getConfigurationModuleForClass(name, ConfigurationCategory.PARSER);
 		return  (module == null) ? new ArrayList<FormatEntry>() : module.getFormatEntries();
 	}
-	
+
 	public ConfigurationModule getConfigurationModuleForClass(String name, ConfigurationCategory moduleCategorie){
-		
+
 		Map<String, ConfigurationModule> activeModules = getActiveConfigurationModules(moduleCategorie);
-		
+
 		for (String moduleName : activeModules.keySet()) {
-			
+
 			ConfigurationModule tmpModule = activeModules.get(moduleName);
-			
+
 			if(!(tmpModule instanceof ClassKnowingModule)){
 				continue;
 			}
-			
+
 			if(((ClassKnowingModule)tmpModule).getClassName().equals(name)){
-				return tmpModule;				
-			}			
+				return tmpModule;
+			}
 		}
 		return null;
 	}
-	
+
 	private Map<String, ConfigurationModule> getActiveConfigurationModules(ConfigurationCategory moduleCategorie){
 		return configurationManager.getConfigurationServices().getActiveConfigurationModulesByCategory(moduleCategorie);
 	}

--- a/52n-wps-commons/src/test/java/org/n52/wps/webapp/common/AbstractITClass.java
+++ b/52n-wps-commons/src/test/java/org/n52/wps/webapp/common/AbstractITClass.java
@@ -16,20 +16,30 @@
  */
 package org.n52.wps.webapp.common;
 
+import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.n52.wps.commons.WPSConfig;
+import org.n52.wps.webapp.api.ConfigurationManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:applicationContext.xml", 
+@ContextConfiguration(locations = {"classpath:applicationContext.xml",
 		"classpath:dispatcher-servlet.xml"})
 @WebAppConfiguration
 @ActiveProfiles("test")
 public class AbstractITClass {
 	@Autowired
 	protected WebApplicationContext wac;
+
+    @Before
+    public void setup() {
+        MockMvcBuilders.webAppContextSetup(this.wac).build();
+		WPSConfig.getInstance().setConfigurationManager(this.wac.getBean(ConfigurationManager.class));
+    }
 }

--- a/52n-wps-commons/src/test/java/org/n52/wps/webapp/common/AbstractITClassForControllerTests.java
+++ b/52n-wps-commons/src/test/java/org/n52/wps/webapp/common/AbstractITClassForControllerTests.java
@@ -16,26 +16,36 @@
  */
 package org.n52.wps.webapp.common;
 
+import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.n52.wps.commons.WPSConfig;
+import org.n52.wps.webapp.api.ConfigurationManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
- * Loads Testmodules, which are omitted for other tests. 
- * 
+ * Loads Testmodules, which are omitted for other tests.
+ *
  * @author Benjamin Pross
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:applicationContext.xml", 
+@ContextConfiguration(locations = {"classpath:applicationContext.xml",
 		"classpath:dispatcher-servlet.xml"})
 @WebAppConfiguration
 @ActiveProfiles("controller-test")
 public class AbstractITClassForControllerTests {
 	@Autowired
 	protected WebApplicationContext wac;
+
+    @Before
+    public void setup() {
+        MockMvcBuilders.webAppContextSetup(this.wac).build();
+		WPSConfig.getInstance().setConfigurationManager(this.wac.getBean(ConfigurationManager.class));
+    }
 }

--- a/52n-wps-io-geotools/src/test/java/org/n52/wps/io/test/datahandler/OMGeneratorTest.java
+++ b/52n-wps-io-geotools/src/test/java/org/n52/wps/io/test/datahandler/OMGeneratorTest.java
@@ -79,36 +79,36 @@ import com.vividsolutions.jts.geom.Point;
 
 /**
  * @author <a href="mailto:e.h.juerrens@52north.org">Eike Hinderk J&uuml;rrens</a>
- * 
+ *
  * @since 4.0.0
  *
  */
 public class OMGeneratorTest extends AbstractTestCase<OMGenerator> {
-	
+
 	private static final String SCHEMA = "http://www.opengis.net/om/2.0";
 	private static final String MIME_TYPE = "application/om+xml; version=2.0";
-	
+
 	@Test
 	public void shouldReturnNullIfInputIsWrong() throws IOException {
 		InputStream result = dataHandler.generateStream(null, null, null);
 		assertThat(result, is(nullValue()));
-		
+
 		result = dataHandler.generateStream(null, "test", null);
 		assertThat(result, is(nullValue()));
-		
+
 		result = dataHandler.generateStream(null, MIME_TYPE, null);
 		assertThat(result, is(nullValue()));
-		
+
 		result = dataHandler.generateStream(null, MIME_TYPE, "test");
 		assertThat(result, is(nullValue()));
-		
+
 		result = dataHandler.generateStream(null, MIME_TYPE, SCHEMA);
 		assertThat(result, is(nullValue()));
-		
+
 		result = dataHandler.generateStream(new OMObservationBinding(null), MIME_TYPE, SCHEMA);
 		assertThat(result, is(nullValue()));
 	}
-	
+
 	@Test
 	@Ignore("no xmloptions injected yet")
 	public void shouldEncodeSingleOMObservationToXML() throws IOException {
@@ -158,7 +158,7 @@ public class OMGeneratorTest extends AbstractTestCase<OMGenerator> {
 		InputStream generatedStream = dataHandler.generateStream(dataToEncode, MIME_TYPE, SCHEMA);
 		assertThat(generatedStream, is(not(nullValue())));
 		assertThat(generatedStream, instanceOf(InputStream.class));
-		
+
 		OMObservationBinding parsedObservationBinding = new OMParser().parse(generatedStream, MIME_TYPE, SCHEMA);
 		assertThat(parsedObservationBinding, is(not(nullValue())));
 		OmObservation parsedObservation = parsedObservationBinding.getPayload();
@@ -187,5 +187,5 @@ public class OMGeneratorTest extends AbstractTestCase<OMGenerator> {
 	protected void initializeDataHandler() {
 		dataHandler = new OMGenerator();
 	}
-	
+
 }

--- a/52n-wps-io/src/test/java/org/n52/wps/io/test/datahandler/AbstractTestCase.java
+++ b/52n-wps-io/src/test/java/org/n52/wps/io/test/datahandler/AbstractTestCase.java
@@ -34,16 +34,14 @@ public abstract class AbstractTestCase<T  extends AbstractIOHandler> extends Abs
 
 	protected T dataHandler;
 
-	public AbstractTestCase() {        	
+	public AbstractTestCase() {
 		 File f = new File(this.getClass().getProtectionDomain().getCodeSource()
 				 .getLocation().getFile());
 				 projectRoot = f.getParentFile().getParentFile().getParent();
     }
-	
+
 	@Before
 	public void setUp(){
-		MockMvcBuilders.webAppContextSetup(this.wac).build();
-		WPSConfig.getInstance().setConfigurationManager(this.wac.getBean(ConfigurationManager.class));		
 		initializeDataHandler();
 	}
 

--- a/52n-wps-r/src/main/java/org/n52/wps/server/r/LocalRAlgorithmRepository.java
+++ b/52n-wps-r/src/main/java/org/n52/wps/server/r/LocalRAlgorithmRepository.java
@@ -75,7 +75,8 @@ public class LocalRAlgorithmRepository implements ITransactionalAlgorithmReposit
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LocalRAlgorithmRepository.class);
 
-    public static final String COMPONENT_NAME = "RAlgorithmRepository";
+//    static final String COMPONENT_NAME = "RAlgorithmRepository";
+    static final String COMPONENT_NAME = "org.n52.wps.server.r.RConfigurationModule";
 
     private static final String DESCRPTION_VERSION_FOR_VALIDATION = WPSConfig.VERSION_100;
 

--- a/52n-wps-r/src/main/java/org/n52/wps/server/r/RConfigurationModule.java
+++ b/52n-wps-r/src/main/java/org/n52/wps/server/r/RConfigurationModule.java
@@ -42,7 +42,9 @@ import org.n52.wps.webapp.api.types.ConfigurationEntry;
 import org.n52.wps.webapp.api.types.StringConfigurationEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
+//@Component("rActualConfigurationModule")
 public class RConfigurationModule extends ClassKnowingModule {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(RConfigurationModule.class);
@@ -103,14 +105,6 @@ public class RConfigurationModule extends ClassKnowingModule {
 	private boolean scriptDownloadEnabled;
 	private boolean sessionInfoDownloadEnabled;
 
-//	private AlgorithmEntry algorithmEntry = new AlgorithmEntry("org.n52.wps.server.algorithm.JTSConvexHullAlgorithm", true);
-//	private AlgorithmEntry algorithmEntry1 = new AlgorithmEntry("org.n52.wps.server.algorithm.test.DummyTestClass", true);
-//	private AlgorithmEntry algorithmEntry2 = new AlgorithmEntry("org.n52.wps.server.algorithm.test.LongRunningDummyTestClass", true);
-//	private AlgorithmEntry algorithmEntry3 = new AlgorithmEntry("org.n52.wps.server.algorithm.test.MultipleComplexInAndOutputsDummyTestClass", true);
-//	private AlgorithmEntry algorithmEntry4 = new AlgorithmEntry("org.n52.wps.server.algorithm.test.MultiReferenceInputAlgorithm", true);
-//	private AlgorithmEntry algorithmEntry5 = new AlgorithmEntry("org.n52.wps.server.algorithm.test.MultiReferenceBinaryInputAlgorithm", true);
-//	private AlgorithmEntry algorithmEntry6 = new AlgorithmEntry("org.n52.wps.server.algorithm.test.EchoProcess", true);
-
 	private List<AlgorithmEntry> algorithmEntries;
 
 	private List<? extends ConfigurationEntry<?>> configurationEntries = Arrays.asList(enableBatchStartEntry,datatypeConfigEntry,
@@ -119,8 +113,7 @@ public class RConfigurationModule extends ClassKnowingModule {
 			importDownloadEnabledEntry,scriptDownloadEnabledEntry,sessionInfoDownloadEnabledEntry);
 
 	public RConfigurationModule() {
-		algorithmEntries = new ArrayList<>();
-//		algorithmEntries.addAll(Arrays.asList(algorithmEntry, algorithmEntry1, algorithmEntry2, algorithmEntry3, algorithmEntry4, algorithmEntry5, algorithmEntry6));
+        algorithmEntries = new ArrayList<>();
 	}
 
 	@Override

--- a/52n-wps-server/src/main/java/org/n52/wps/server/CapabilitiesConfiguration.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/CapabilitiesConfiguration.java
@@ -61,10 +61,10 @@ import com.google.common.base.Preconditions;
  * {@linkplain #getInstance(java.io.File) file}, {@linkplain #getInstance(java.net.URL) URL},
  * {@linkplain #getInstance(java.lang.String) path} or
  * {@linkplain #getInstance(net.opengis.wps.x100.CapabilitiesDocument) instance}.
- * 
+ *
  * @author foerster
  * @author Christian Autermann
- * 
+ *
  */
 public class CapabilitiesConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(CapabilitiesConfiguration.class);
@@ -87,12 +87,12 @@ public class CapabilitiesConfiguration {
      * Gets the WPS Capabilities using the specified file to obtain the skeleton. All future calls to
      * {@link #getInstance()} and {@link #getInstance(boolean)
      * } will use this file to obtain the skeleton.
-     * 
+     *
      * @param filePath
      *        the File pointing to a skeleton
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -106,12 +106,12 @@ public class CapabilitiesConfiguration {
      * Gets the WPS Capabilities using the specified file to obtain the skeleton. All future calls to
      * {@link #getInstance()} and {@link #getInstance(boolean)
      * } will use this file to obtain the skeleton.
-     * 
+     *
      * @param file
      *        the File pointing to a skeleton
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -125,12 +125,12 @@ public class CapabilitiesConfiguration {
      * Gets the WPS Capabilities using the specified URL to obtain the skeleton. All future calls to
      * {@link #getInstance()} and {@link #getInstance(boolean)
      * } will use this URL to obtain the skeleton.
-     * 
+     *
      * @param url
      *        the URL pointing to a skeleton
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -143,12 +143,12 @@ public class CapabilitiesConfiguration {
     /**
      * Gets the WPS Capabilities using the specified skeleton. All future calls to {@link #getInstance()} and
      * {@link #getInstance(boolean) } will use this skeleton.
-     * 
+     *
      * @param skel
      *        the skeleton
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -161,12 +161,12 @@ public class CapabilitiesConfiguration {
     /**
      * Gets the WPS Capabilities using the specified strategy. All future calls to {@link #getInstance()} and
      * {@link #getInstance(boolean) } will use this strategy.
-     * 
+     *
      * @param strategy
      *        the strategy to load the skeleton
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -191,9 +191,9 @@ public class CapabilitiesConfiguration {
     /**
      * Get the WPS Capabilities for this service. The capabilities are reloaded if caching is not enabled in
      * the WPS configuration.
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -206,12 +206,12 @@ public class CapabilitiesConfiguration {
 
     /**
      * Get the WPS Capabilities for this service and optionally force a reload.
-     * 
+     *
      * @param reload
      *        if the capabilities should be reloaded
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -233,10 +233,10 @@ public class CapabilitiesConfiguration {
 
     /**
      * Enriches a capabilities skeleton by adding the endpoint URL and creating the process offerings.
-     * 
+     *
      * @param skel
      *        the skeleton to enrich
-     * 
+     *
      * @throws UnknownHostException
      *         if the local host name can not be obtained
      */
@@ -251,21 +251,21 @@ public class CapabilitiesConfiguration {
 
     /**
      * Enriches the capabilities skeleton by creating the process offerings.
-     * 
+     *
      * @param skel
      *        the skeleton to enrich
      */
     private static void initProcessOfferings(CapabilitiesDocument skel) {
         ProcessOfferings processes = skel.getCapabilities()
                 .addNewProcessOfferings();
-        RepositoryManager rm = RepositoryManager.getInstance();
+        RepositoryManager rm = RepositoryManagerSingletonWrapper.getInstance();
         List<String> algorithms = rm.getAlgorithms();
         if (algorithms.isEmpty())
             LOG.warn("No algorithms found in repository manager.");
 
         for (String algorithmName : algorithms) {
         	try {
-        		ProcessDescriptionType description = (ProcessDescriptionType) RepositoryManager
+        		ProcessDescriptionType description = (ProcessDescriptionType) RepositoryManagerSingletonWrapper
                         .getInstance().getProcessDescription(algorithmName).getProcessDescriptionType(WPSConfig.VERSION_100);
                 if (description != null) {
                     ProcessBriefType process = processes.addNewProcess();
@@ -276,7 +276,7 @@ public class CapabilitiesConfiguration {
                     process.setProcessVersion(processVersion);
                     process.setTitle(title);
                     LOG.trace("Added algorithm to process offerings: {}\n\t\t{}", algorithmName, process);
-                }	
+                }
         	}
         	catch (RuntimeException e) {
         		LOG.warn("Exception during instantiation of process {}", algorithmName, e);
@@ -286,12 +286,12 @@ public class CapabilitiesConfiguration {
 
     /**
      * Enriches a capabilities skeleton by adding the endpoint URL to the operations meta data.
-     * 
+     *
      * @param skel
      *        the skeleton to enrich
      * @param endpointUrl
      *        the endpoint URL of the service
-     * 
+     *
      */
     private static void initOperationsMetadata(CapabilitiesDocument skel, String endpointUrl) {
         if (skel.getCapabilities().getOperationsMetadata() != null) {
@@ -312,9 +312,9 @@ public class CapabilitiesConfiguration {
 
     /**
      * Gets the endpoint URL of this service by checking the configuration file and the local host name.
-     * 
+     *
      * @return the endpoint URL
-     * 
+     *
      * @throws UnknownHostException
      *         if the local host name could not be resolved into an address
      */
@@ -325,7 +325,7 @@ public class CapabilitiesConfiguration {
 
     /**
      * Force a reload of the capabilities skeleton.
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -337,7 +337,7 @@ public class CapabilitiesConfiguration {
 
     /**
      * Checks if the capabilities document is loaded.
-     * 
+     *
      * @return if the capabilities are ready.
      */
     public static boolean ready() {
@@ -349,7 +349,7 @@ public class CapabilitiesConfiguration {
             lock.unlock();
         }
     }
-    
+
 	public static Server getServerConfigurationModule() {
 
 		if (serverConfigurationModule == null) {
@@ -374,7 +374,7 @@ public class CapabilitiesConfiguration {
 
         /**
          * Creates a new strategy using the specified URL.
-         * 
+         *
          * @param file
          *        the file
          */
@@ -404,7 +404,7 @@ public class CapabilitiesConfiguration {
 
         /**
          * Gets the URL of this strategy.
-         * 
+         *
          * @return the URL;
          */
         public URL getUrl() {
@@ -419,7 +419,7 @@ public class CapabilitiesConfiguration {
 
         /**
          * Creates a new strategy using the specified file.
-         * 
+         *
          * @param file
          *        the file
          */
@@ -429,7 +429,7 @@ public class CapabilitiesConfiguration {
 
         /**
          * Creates a new strategy using the specified file.
-         * 
+         *
          * @param file
          *        the path to the file
          */
@@ -447,7 +447,7 @@ public class CapabilitiesConfiguration {
 
         /**
          * Creates a new strategy using the specified instance.
-         * 
+         *
          * @param instance
          *        the instance
          */
@@ -476,7 +476,7 @@ public class CapabilitiesConfiguration {
 
         /**
          * Gets the instance of this strategy.
-         * 
+         *
          * @return the instance
          */
         public CapabilitiesDocument getInstance() {
@@ -490,9 +490,9 @@ public class CapabilitiesConfiguration {
     private interface CapabilitiesSkeletonLoadingStrategy {
         /**
          * Loads a CapabilitiesDocument skeleton. Every call to this method should return another instance.
-         * 
+         *
          * @return the capabilities skeleton
-         * 
+         *
          * @throws XmlException
          *         if the Capabilities skeleton is not valid
          * @throws IOException

--- a/52n-wps-server/src/main/java/org/n52/wps/server/CapabilitiesConfigurationV200.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/CapabilitiesConfigurationV200.java
@@ -73,11 +73,11 @@ import com.google.common.base.Preconditions;
  * {@linkplain #getInstance(java.io.File) file}, {@linkplain #getInstance(java.net.URL) URL},
  * {@linkplain #getInstance(java.lang.String) path} or
  * {@linkplain #getInstance(net.opengis.wps.x200.CapabilitiesDocument) instance}.
- * 
+ *
  * @author foerster
  * @author Christian Autermann
  * @author Benjamin Pross
- * 
+ *
  */
 public class CapabilitiesConfigurationV200 {
     private static final Logger LOG = LoggerFactory.getLogger(CapabilitiesConfigurationV200.class);
@@ -89,8 +89,8 @@ public class CapabilitiesConfigurationV200 {
     private static CapabilitiesSkeletonLoadingStrategy loadingStrategy;
 
     private static ConfigurationManager configurationManager;
-    private static org.n52.wps.webapp.entities.ServiceIdentification serviceIdentificationConfigurationModule;	
-    private static org.n52.wps.webapp.entities.ServiceProvider serviceProviderConfigurationModule;	
+    private static org.n52.wps.webapp.entities.ServiceIdentification serviceIdentificationConfigurationModule;
+    private static org.n52.wps.webapp.entities.ServiceProvider serviceProviderConfigurationModule;
 
     private CapabilitiesConfigurationV200() {
         /* nothing here */
@@ -100,12 +100,12 @@ public class CapabilitiesConfigurationV200 {
      * Gets the WPS Capabilities using the specified file to obtain the skeleton. All future calls to
      * {@link #getInstance()} and {@link #getInstance(boolean)
      * } will use this file to obtain the skeleton.
-     * 
+     *
      * @param filePath
      *        the File pointing to a skeleton
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -119,12 +119,12 @@ public class CapabilitiesConfigurationV200 {
      * Gets the WPS Capabilities using the specified file to obtain the skeleton. All future calls to
      * {@link #getInstance()} and {@link #getInstance(boolean)
      * } will use this file to obtain the skeleton.
-     * 
+     *
      * @param file
      *        the File pointing to a skeleton
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -138,12 +138,12 @@ public class CapabilitiesConfigurationV200 {
      * Gets the WPS Capabilities using the specified URL to obtain the skeleton. All future calls to
      * {@link #getInstance()} and {@link #getInstance(boolean)
      * } will use this URL to obtain the skeleton.
-     * 
+     *
      * @param url
      *        the URL pointing to a skeleton
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -156,12 +156,12 @@ public class CapabilitiesConfigurationV200 {
     /**
      * Gets the WPS Capabilities using the specified skeleton. All future calls to {@link #getInstance()} and
      * {@link #getInstance(boolean) } will use this skeleton.
-     * 
+     *
      * @param skel
      *        the skeleton
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -174,12 +174,12 @@ public class CapabilitiesConfigurationV200 {
     /**
      * Gets the WPS Capabilities using the specified strategy. All future calls to {@link #getInstance()} and
      * {@link #getInstance(boolean) } will use this strategy.
-     * 
+     *
      * @param strategy
      *        the strategy to load the skeleton
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -204,9 +204,9 @@ public class CapabilitiesConfigurationV200 {
     /**
      * Get the WPS Capabilities for this service. The capabilities are reloaded if caching is not enabled in
      * the WPS configuration.
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -219,12 +219,12 @@ public class CapabilitiesConfigurationV200 {
 
     /**
      * Get the WPS Capabilities for this service and optionally force a reload.
-     * 
+     *
      * @param reload
      *        if the capabilities should be reloaded
-     * 
+     *
      * @return the capabilities document
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -234,11 +234,11 @@ public class CapabilitiesConfigurationV200 {
         lock.lock();
         try {
             if (capabilitiesDocumentObj == null || reload) {
-            	
+
             	if(loadingStrategy == null){
             		loadingStrategy = new CreateInstanceStrategy();
             	}
-            	
+
                 capabilitiesDocumentObj = loadingStrategy.loadSkeleton();
                 initSkeleton(capabilitiesDocumentObj);
             }
@@ -251,10 +251,10 @@ public class CapabilitiesConfigurationV200 {
 
     /**
      * Enriches a capabilities skeleton by adding the endpoint URL and creating the process offerings.
-     * 
+     *
      * @param skel
      *        the skeleton to enrich
-     * 
+     *
      * @throws UnknownHostException
      *         if the local host name can not be obtained
      */
@@ -269,21 +269,21 @@ public class CapabilitiesConfigurationV200 {
 
     /**
      * Enriches the capabilities skeleton by creating the process offerings.
-     * 
+     *
      * @param skel
      *        the skeleton to enrich
      */
     private static void initProcessOfferings(CapabilitiesDocument skel) {
         Contents contents = skel.getCapabilities()
                 .addNewContents();
-        for (String algorithmName : RepositoryManager.getInstance()
+        for (String algorithmName : RepositoryManagerSingletonWrapper.getInstance()
                 .getAlgorithms()) {
         	try {
-        		ProcessOffering offering = (ProcessOffering) RepositoryManager
+        		ProcessOffering offering = (ProcessOffering) RepositoryManagerSingletonWrapper
                         .getInstance().getProcessDescription(algorithmName).getProcessDescriptionType(WPSConfig.VERSION_200);
-        		
+
         		ProcessDescriptionType description = offering.getProcess();
-        		
+
                 if (description != null) {
                     ProcessSummaryType process = contents.addNewProcessSummary();
                     CodeType ct = process.addNewIdentifier();
@@ -291,21 +291,21 @@ public class CapabilitiesConfigurationV200 {
                     //a title is mandatory for a process offering
                     LanguageStringType title = null;
                     try {
-                        title = description.getTitleArray(0);						
+                        title = description.getTitleArray(0);
 					} catch (Exception e) {
 						throw new RuntimeException(String.format("Process offering for process '{}' not valid. No title specified.", algorithmName));
 					}
                     String processVersion = offering.getProcessVersion();
                     process.setProcessVersion(processVersion);
-                    
+
                     process.setJobControlOptions(offering.getJobControlOptions());
-                    
+
                     process.setOutputTransmission(offering.getOutputTransmission());
 
                     process.addNewTitle().setStringValue(title.getStringValue());
-                    
+
                     LOG.trace("Added algorithm to process offerings: {}\n\t\t{}", algorithmName, process);
-                }	
+                }
         	}
         	catch (RuntimeException e) {
         		LOG.warn("Exception during instantiation of process {}", algorithmName, e);
@@ -315,12 +315,12 @@ public class CapabilitiesConfigurationV200 {
 
     /**
      * Enriches a capabilities skeleton by adding the endpoint URL to the operations meta data.
-     * 
+     *
      * @param skel
      *        the skeleton to enrich
      * @param endpointUrl
      *        the endpoint URL of the service
-     * 
+     *
      */
     private static void initOperationsMetadata(CapabilitiesDocument skel, String endpointUrl) {
         if (skel.getCapabilities().getOperationsMetadata() != null) {
@@ -341,9 +341,9 @@ public class CapabilitiesConfigurationV200 {
 
     /**
      * Gets the endpoint URL of this service by checking the configuration file and the local host name.
-     * 
+     *
      * @return the endpoint URL
-     * 
+     *
      * @throws UnknownHostException
      *         if the local host name could not be resolved into an address
      */
@@ -353,7 +353,7 @@ public class CapabilitiesConfigurationV200 {
 
     /**
      * Force a reload of the capabilities skeleton.
-     * 
+     *
      * @throws XmlException
      *         if the Capabilities skeleton is not valid
      * @throws IOException
@@ -365,7 +365,7 @@ public class CapabilitiesConfigurationV200 {
 
     /**
      * Checks if the capabilities document is loaded.
-     * 
+     *
      * @return if the capabilities are ready.
      */
     public static boolean ready() {
@@ -377,7 +377,7 @@ public class CapabilitiesConfigurationV200 {
             lock.unlock();
         }
     }
-    
+
 	public static ConfigurationManager getConfigurationManager() {
 
 		if (configurationManager == null) {
@@ -395,7 +395,7 @@ public class CapabilitiesConfigurationV200 {
 
         /**
          * Creates a new strategy using the specified URL.
-         * 
+         *
          * @param file
          *        the file
          */
@@ -425,7 +425,7 @@ public class CapabilitiesConfigurationV200 {
 
         /**
          * Gets the URL of this strategy.
-         * 
+         *
          * @return the URL;
          */
         public URL getUrl() {
@@ -440,7 +440,7 @@ public class CapabilitiesConfigurationV200 {
 
         /**
          * Creates a new strategy using the specified file.
-         * 
+         *
          * @param file
          *        the file
          */
@@ -450,7 +450,7 @@ public class CapabilitiesConfigurationV200 {
 
         /**
          * Creates a new strategy using the specified file.
-         * 
+         *
          * @param file
          *        the path to the file
          */
@@ -468,7 +468,7 @@ public class CapabilitiesConfigurationV200 {
 
         /**
          * Creates a new strategy using the specified instance.
-         * 
+         *
          * @param instance
          *        the instance
          */
@@ -497,7 +497,7 @@ public class CapabilitiesConfigurationV200 {
 
         /**
          * Gets the instance of this strategy.
-         * 
+         *
          * @return the instance
          */
         public CapabilitiesDocument getInstance() {
@@ -513,100 +513,100 @@ public class CapabilitiesConfigurationV200 {
 
         /**
          * Creates a new strategy using the specified instance.
-         * 
+         *
          * @param instance
          *        the instance
          */
         CreateInstanceStrategy() {
             this.instance = CapabilitiesDocument.Factory.newInstance();
-            
+
             serviceIdentificationConfigurationModule = getConfigurationManager().getCapabilitiesServices().getServiceIdentification();
-            
+
             serviceProviderConfigurationModule = getConfigurationManager().getCapabilitiesServices().getServiceProvider();
-            
+
             WPSCapabilitiesType wpsCapabilities = instance.addNewCapabilities();
-            
+
             XmlCursor c = instance.newCursor();
             c.toFirstChild();
             c.toLastAttribute();
             c.setAttributeText(new QName(XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, "schemaLocation"), "http://www.opengis.net/wps/2.0 http://schemas.opengis.net/wps/2.0/wps.xsd");
-            
+
             wpsCapabilities.addNewService().setStringValue("WPS");//Fixed to WPS TODO: put in WPSConfig or so
-            
+
             wpsCapabilities.setVersion(WPSConfig.VERSION_200);
-            
+
             ServiceProvider serviceProvider = wpsCapabilities.addNewServiceProvider();
-            
+
             serviceProvider.setProviderName(serviceProviderConfigurationModule.getProviderName() != null ? serviceProviderConfigurationModule.getProviderName() : "");
-            
+
             serviceProvider.addNewProviderSite().setHref(serviceProviderConfigurationModule.getProviderSite() != null ? serviceProviderConfigurationModule.getProviderSite() : "");
-                        
+
             ResponsiblePartySubsetType responsiblePartySubsetType = serviceProvider.addNewServiceContact();
-            
+
             responsiblePartySubsetType.setIndividualName(serviceProviderConfigurationModule.getIndividualName() != null ? serviceProviderConfigurationModule.getIndividualName() : "");
-            
+
             ContactType contactType = responsiblePartySubsetType.addNewContactInfo();
-            
+
             AddressType addressType = contactType.addNewAddress();
-            
+
             addressType.setAdministrativeArea(serviceProviderConfigurationModule.getAdministrativeArea() != null ? serviceProviderConfigurationModule.getAdministrativeArea() : "");
-            
+
             addressType.setCity(serviceProviderConfigurationModule.getCity() != null ? serviceProviderConfigurationModule.getCity() : "");
-            
+
             addressType.setCountry(serviceProviderConfigurationModule.getCountry() != null ? serviceProviderConfigurationModule.getCountry() : "");
-            
+
             addressType.setPostalCode(serviceProviderConfigurationModule.getPostalCode() != null ? serviceProviderConfigurationModule.getPostalCode() : "");
-     
+
             addressType.addDeliveryPoint(serviceProviderConfigurationModule.getDeliveryPoint() != null ? serviceProviderConfigurationModule.getDeliveryPoint() : "");
-            
+
             addressType.addElectronicMailAddress(serviceProviderConfigurationModule.getEmail() != null ? serviceProviderConfigurationModule.getEmail() : "");
-            
+
             ServiceIdentification serviceIdentification = wpsCapabilities.addNewServiceIdentification();
-            
+
             serviceIdentification.addNewTitle().setStringValue(serviceIdentificationConfigurationModule.getTitle() != null ? serviceIdentificationConfigurationModule.getTitle() : "");
-            
+
             serviceIdentification.addAccessConstraints(serviceIdentificationConfigurationModule.getAccessConstraints() != null ? serviceIdentificationConfigurationModule.getAccessConstraints() : "");
-            
+
             serviceIdentification.addNewAbstract().setStringValue(serviceIdentificationConfigurationModule.getServiceAbstract() != null ? serviceIdentificationConfigurationModule.getServiceAbstract() : "");
-            
+
             serviceIdentification.addNewServiceType().setStringValue("WPS");//Fixed to WPS
-            
-            String[] versionArray = serviceIdentificationConfigurationModule.getServiceTypeVersions().split(";");  
-            
+
+            String[] versionArray = serviceIdentificationConfigurationModule.getServiceTypeVersions().split(";");
+
             for (String version : versionArray) {
 				if(version.trim() != ""){
 					serviceIdentification.addNewServiceTypeVersion().setStringValue(version);
 				}
 			}
-            
+
             serviceIdentification.setFees(serviceIdentificationConfigurationModule.getFees() != null ? serviceIdentificationConfigurationModule.getFees() : "");
-            
-            String[] keywordArray = serviceIdentificationConfigurationModule.getKeywords().split(";");  
-            
+
+            String[] keywordArray = serviceIdentificationConfigurationModule.getKeywords().split(";");
+
             KeywordsType keywordsType = serviceIdentification.addNewKeywords();
-            
+
             for (String keyword : keywordArray) {
 				if(keyword.trim() != ""){
 					keywordsType.addNewKeyword().setStringValue(keyword);
 				}
 			}
-            
+
             OperationsMetadata operationsMetadata = wpsCapabilities.addNewOperationsMetadata();
-            
+
             String wpsWebappPath = WPSConfig.getInstance().getServiceBaseUrl();
-            
+
             String getHREF = wpsWebappPath.endsWith("/") ? wpsWebappPath.substring(0, wpsWebappPath.length()-1) : wpsWebappPath;
-            
+
             getHREF = getHREF.concat("?");
-            
+
             String postHREF = wpsWebappPath;
-            
+
             addOperation(operationsMetadata, "GetCapabilities", getHREF, postHREF);
             addOperation(operationsMetadata, "DescribeProcess", getHREF, postHREF);
             addOperation(operationsMetadata, "Execute", "", postHREF);
             addOperation(operationsMetadata, "GetStatus", getHREF, postHREF);
             addOperation(operationsMetadata, "GetResult", getHREF, postHREF);
-            
+
             wpsCapabilities.addNewLanguages().addLanguage("en-US");
         }
 
@@ -631,40 +631,40 @@ public class CapabilitiesConfigurationV200 {
 
         /**
          * Gets the instance of this strategy.
-         * 
+         *
          * @return the instance
          */
         public CapabilitiesDocument getInstance() {
             return instance;
         }
-        
+
         private void addOperation(OperationsMetadata operationsMetadata, String operationName, String getHREF, String postHREF){
-                 
+
             Operation operation = operationsMetadata.addNewOperation();
-            
+
             operation.setName(operationName);
-            
+
             HTTP http = operation.addNewDCP().addNewHTTP();
-            
+
             if(getHREF != null && !getHREF.equals("")){
-            	http.addNewGet().setHref(getHREF);            	            	
+            	http.addNewGet().setHref(getHREF);
             }
             if(postHREF != null && !postHREF.equals("")){
-            	http.addNewPost().setHref(postHREF);            	            	
+            	http.addNewPost().setHref(postHREF);
             }
-        	
+
         }
     }
-    
+
     /**
      * Strategy to load a capabilities skeleton.
      */
     private interface CapabilitiesSkeletonLoadingStrategy {
         /**
          * Loads a CapabilitiesDocument skeleton. Every call to this method should return another instance.
-         * 
+         *
          * @return the capabilities skeleton
-         * 
+         *
          * @throws XmlException
          *         if the Capabilities skeleton is not valid
          * @throws IOException

--- a/52n-wps-server/src/main/java/org/n52/wps/server/RepositoryManager.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/RepositoryManager.java
@@ -40,102 +40,106 @@ import org.n52.wps.webapp.api.ClassKnowingModule;
 import org.n52.wps.webapp.api.ConfigurationModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanNotOfRequiredTypeException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
 
 /**
  * @author Bastian Schaeffer, University of Muenster
  *
  */
-public class RepositoryManager {
-	
-	private static RepositoryManager instance;
+public class RepositoryManager implements ApplicationContextAware {
+
 	private static Logger LOGGER = LoggerFactory.getLogger(RepositoryManager.class);
-	private Map<String, IAlgorithmRepository> repositories;
-	private ProcessIDRegistry globalProcessIDs = ProcessIDRegistry.getInstance();
-	private UpdateThread updateThread;
-	
-	private RepositoryManager(){
-		
-		// clear registry
+
+    private ApplicationContext applicationContext;
+
+    private Map<String, IAlgorithmRepository> repositories = new HashMap<>();
+
+    private ProcessIDRegistry globalProcessIDs = ProcessIDRegistry.getInstance();
+
+    private UpdateThread updateThread;
+
+    public void init() {
+        RepositoryManagerSingletonWrapper.init(this);
+
 		globalProcessIDs.clearRegistry();
-		
-        // initialize all Repositories
         loadAllRepositories();
 
         // FvK: added Property Change Listener support
         // creates listener and register it to the wpsConfig instance.
-        WPSConfig.getInstance().addPropertyChangeListener(WPSConfig.WPSCONFIG_PROPERTY_EVENT_NAME, new PropertyChangeListener() {
-            public void propertyChange(
-                    final PropertyChangeEvent propertyChangeEvent) {
-                                                                  LOGGER.info("Received Property Change Event: {}",
-                                                                              propertyChangeEvent.getPropertyName());
-                loadAllRepositories();
-            }
-        });
-        
+        WPSConfig.getInstance().addPropertyChangeListener(WPSConfig.WPSCONFIG_PROPERTY_EVENT_NAME,
+                (final PropertyChangeEvent propertyChangeEvent) -> {
+                    LOGGER.info("Received Property Change Event: {}",
+                            propertyChangeEvent.getPropertyName());
+                    loadAllRepositories();
+                });
+
         Double updateHours = WPSConfig.getInstance().getWPSConfig().getServerConfigurationModule().getRepoReloadInterval();
-        
         if (updateHours != 0){
             LOGGER.info("Setting repository update period to {} hours.", updateHours);
         	updateHours = updateHours * 3600 * 1000; // make milliseconds
             long updateInterval = updateHours.longValue();
-            this.updateThread = new UpdateThread(updateInterval);
+            this.updateThread = new UpdateThread(this, updateInterval);
         	updateThread.start();
         }
-        
-    	
-	}
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
 
 	private List<String> getRepositoryNames(){
-		
+
 		List<String> repositoryNames = new ArrayList<>();
-		
-		Map<String, ConfigurationModule> repositoryMap = WPSConfig.getInstance().getRegisteredAlgorithmRepositoryConfigModules();
-		
+
+		Map<String, ConfigurationModule> repositoryMap = WPSConfig.getInstance()
+                .getRegisteredAlgorithmRepositoryConfigModules();
+
 		for (ConfigurationModule repository : repositoryMap.values()) {
-			
 			if(repository.isActive()==false){
 				continue;
 			}
-			
-			String repositoryClassName = "";
-			
+
 			if(repository instanceof ClassKnowingModule){
-				repositoryClassName = ((ClassKnowingModule)repository).getClassName();
+				String repositoryClassName = ((ClassKnowingModule)repository).getClassName();
 				repositoryNames.add(repositoryClassName);
 				if(!repositories.containsKey(repositoryClassName)){
 					loadRepository(repository.getClass().getCanonicalName(), repositoryClassName, repositoryMap);
 				}
 			}
-			
+
 		}
-		
+
 		return repositoryNames;
 	}
-	
+
     private void loadAllRepositories(){
         repositories = new HashMap<String, IAlgorithmRepository>();
         LOGGER.debug("Loading all repositories: {} (doing a gc beforehand...)", repositories);//FIXME not sure log statement makes a lot of sense
 
         System.gc();
 
-		Map<String, ConfigurationModule> repositoryMap = WPSConfig.getInstance().getRegisteredAlgorithmRepositoryConfigModules();
-			
+		Map<String, ConfigurationModule> repositoryMap = WPSConfig.getInstance()
+                .getRegisteredAlgorithmRepositoryConfigModules();
+
 		for (String repositoryName : repositoryMap.keySet()) {
 
 			ConfigurationModule repository = repositoryMap.get(repositoryName);
-			
-			String repositoryClassName = "";
 
 			if (repository instanceof ClassKnowingModule) {
-				repositoryClassName = ((ClassKnowingModule) repository)
-						.getClassName();				
+				String repositoryClassName = ((ClassKnowingModule) repository).getClassName();
 				 loadRepository(repositoryName, repositoryClassName, repositoryMap);
-			}else{
+			} else {
 				LOGGER.warn("Repository {} not instanceof ClassKnowingModule. Will not load it.", repositoryName);
 			}
 		}
     }
-	
+
 	private void loadRepository(String repositoryName, String repositoryClassName, Map<String, ConfigurationModule> repositoryMap) {
 		LOGGER.debug("Loading repository: {}", repositoryName);
 
@@ -151,57 +155,42 @@ public class RepositoryManager {
 			return;
 		}
 
-		try {
-			IAlgorithmRepository algorithmRepository = null;
+		//registerNewRepository(repositoryClassName);
+        registerRepository(repositoryName, repositoryClassName);
+	}
 
-			Class<?> repositoryClass = RepositoryManager.class.getClassLoader()
+    private void registerRepository(String name, String className) {
+        try {
+            repositories.put(className, applicationContext.getBean(name, IAlgorithmRepository.class));
+        } catch (NoSuchBeanDefinitionException e) {
+            LOGGER.warn("Try creating repository the old fashioned way.", className, name);
+            registerNewRepository(className);
+        } catch (BeansException e) {
+            LOGGER.warn("Could not create algorithm repository for class '{}' and name '{}'", className, name, e);
+        }
+    }
+
+    private void registerNewRepository(String repositoryClassName) {
+        try {
+			Class<?> repositoryClass = RepositoryManager.class
+                    .getClassLoader()
 					.loadClass(repositoryClassName);
-
-			algorithmRepository = (IAlgorithmRepository) repositoryClass
+			IAlgorithmRepository algorithmRepository = (IAlgorithmRepository) repositoryClass
 					.newInstance();
-			
-			LOGGER.info("Algorithm Repository {} initialized",
-					repositoryClassName);
+
+			LOGGER.info("Algorithm Repository {} initialized", repositoryClassName);
 			repositories.put(repositoryClassName, algorithmRepository);
-		} catch (InstantiationException e) {
+		} catch (InstantiationException | IllegalAccessException e) {
 			LOGGER.warn(
 					"An error occured while registering AlgorithmRepository: {}",
-					repositoryClassName);
-		} catch (IllegalAccessException e) {
-			// in case of an singleton
+					repositoryClassName, e);
+		} catch (ClassNotFoundException | IllegalArgumentException | SecurityException e) {
 			LOGGER.warn(
 					"An error occured while registering AlgorithmRepository: {}",
-					repositoryClassName);
-		} catch (ClassNotFoundException e) {
-			LOGGER.warn(
-					"An error occured while registering AlgorithmRepository: {}",
-					repositoryClassName, e.getMessage());
-		} catch (IllegalArgumentException e) {
-			LOGGER.warn(
-					"An error occured while registering AlgorithmRepository: {}",
-					repositoryClassName, e.getMessage());
-		} catch (SecurityException e) {
-			LOGGER.warn(
-					"An error occured while registering AlgorithmRepository: {}",
-					repositoryClassName, e.getMessage());
+					repositoryClassName, e);
 		}
-	}
-    
-	public static RepositoryManager getInstance(){
-		if(instance==null){
-			instance = new RepositoryManager();
-		}
-		return instance;
-	}
-	
-	/**
-	 * Allows to reInitialize the RepositoryManager... This should not be called to often.
-	 *
-	 */
-	public static void reInitialize() {
-		instance = new RepositoryManager();
-	}
-	
+    }
+
 	/**
 	 * Allows to reInitialize the Repositories
 	 *
@@ -209,7 +198,7 @@ public class RepositoryManager {
 	protected void reloadRepositories() {
 		loadAllRepositories();
 	}
-	
+
 	/**
 	 * Methods looks for Algorithm in all Repositories.
 	 * The first match is returned.
@@ -220,7 +209,7 @@ public class RepositoryManager {
 	 * @throws Exception
 	 */
 	public IAlgorithm getAlgorithm(String className){
-		
+
 		for (String repositoryClassName : getRepositoryNames()) {
 			IAlgorithmRepository repository = repositories.get(repositoryClassName);
 			if(repository.containsAlgorithm(className)){
@@ -229,9 +218,9 @@ public class RepositoryManager {
 		}
 		return null;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @return allAlgorithms
 	 */
 	public List<String> getAlgorithms(){
@@ -241,7 +230,7 @@ public class RepositoryManager {
 			allAlgorithmNamesCollection.addAll(repository.getAlgorithmNames());
 		}
 		return allAlgorithmNamesCollection;
-		
+
 	}
 
 	public boolean containsAlgorithm(String algorithmName) {
@@ -253,7 +242,7 @@ public class RepositoryManager {
 		}
 		return false;
 	}
-	
+
 	public IAlgorithmRepository getRepositoryForAlgorithm(String algorithmName){
 		for (String repositoryClassName : getRepositoryNames()) {
 			IAlgorithmRepository repository = repositories.get(repositoryClassName);
@@ -263,33 +252,33 @@ public class RepositoryManager {
 		}
 		return null;
 	}
-	
+
 	public Class<?> getInputDataTypeForAlgorithm(String algorithmIdentifier, String inputIdentifier){
 		IAlgorithm algorithm = getAlgorithm(algorithmIdentifier);
 		return algorithm.getInputDataType(inputIdentifier);
-		
+
 	}
-	
+
 	public Class<?> getOutputDataTypeForAlgorithm(String algorithmIdentifier, String inputIdentifier){
 		IAlgorithm algorithm = getAlgorithm(algorithmIdentifier);
 		return algorithm.getOutputDataType(inputIdentifier);
-		
+
 	}
-	
+
 	public boolean registerAlgorithm(String id, IAlgorithmRepository repository){
 		if (globalProcessIDs.addID(id)){
 			return true;
 		}
 		else return false;
 	}
-	
+
 	public boolean unregisterAlgorithm(String id){
 		if (globalProcessIDs.removeID(id)){
 			return true;
 		}
 		else return false;
 	}
-	
+
 	public IAlgorithmRepository getAlgorithmRepository(String name){
 		for (String repositoryClassName : getRepositoryNames()) {
 			IAlgorithmRepository repository = repositories.get(repositoryClassName);
@@ -310,7 +299,7 @@ public class RepositoryManager {
 		}
 		return null;
 	}
-	
+
 	public ProcessDescription getProcessDescription(String processClassName){
 		for (String repositoryClassName : getRepositoryNames()) {
 			IAlgorithmRepository repository = repositories.get(repositoryClassName);
@@ -320,20 +309,24 @@ public class RepositoryManager {
 		}
 		return new ProcessDescription();
 	}
-	
+
     static class UpdateThread extends Thread {
-        
+
     	private final long interval;
+
     	private boolean firstrun = true;
-    	
-    	public UpdateThread (long interval){
+
+        private final RepositoryManager repositoryManager;
+
+    	public UpdateThread (RepositoryManager repositoryManager, long interval){
+            this.repositoryManager = repositoryManager;
     		this.interval = interval;
     	}
-    	
+
         @Override
         public void run() {
         	LOGGER.debug("UpdateThread started");
-        	
+
         	try {
         		// never terminate the run method
         		while (true){
@@ -341,25 +334,26 @@ public class RepositoryManager {
         			if (!firstrun){
         				LOGGER.info("Reloading repositories - this might take a while ...");
             			long timestamp = System.currentTimeMillis();
-            			RepositoryManager.getInstance().reloadRepositories();
+            			repositoryManager.reloadRepositories();
                         LOGGER.info("Repositories reloaded - going to sleep. Took {} seconds.",
                                     (System.currentTimeMillis() - timestamp) / 1000);
         			} else {
         				firstrun = false;
         			}
-        			
+
         			// sleep for a given INTERVAL
-        			sleep(interval);
+        			Thread.sleep(interval);
         		}
 			} catch (InterruptedException e) {
 				LOGGER.debug("Interrupt received - Terminating the UpdateThread.");
 			}
         }
-       
+
     }
-    
+
     // shut down the update thread
-    public void finalize(){
+    public void finalize() throws Throwable {
+        super.finalize();
     	if (updateThread != null){
     		updateThread.interrupt();
     	}

--- a/52n-wps-server/src/main/java/org/n52/wps/server/RepositoryManagerSingletonWrapper.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/RepositoryManagerSingletonWrapper.java
@@ -1,5 +1,5 @@
 /**
- * ﻿Copyright (C) 2007 - 2014 52°North Initiative for Geospatial Open Source
+ * Copyright (C) 2007 - 2014 52°North Initiative for Geospatial Open Source
  * Software GmbH
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/52n-wps-server/src/main/java/org/n52/wps/server/RepositoryManagerSingletonWrapper.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/RepositoryManagerSingletonWrapper.java
@@ -1,0 +1,65 @@
+/**
+ * ﻿Copyright (C) 2007 - 2014 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *       • Apache License, version 2.0
+ *       • Apache Software License, version 1.0
+ *       • GNU Lesser General Public License, version 3
+ *       • Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *       • Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.n52.wps.server;
+
+/**
+ * Wraps {@link RepositoryManager} as it got refactored to IoC managable. This class
+ * determines an intermediate refactor step. To use {@link RepositoryManager} instance
+ * define dependency injection or just {@link Autowire} it.
+ *
+ * @author Henning Bredel <h.bredel@52north.org>
+ */
+public class RepositoryManagerSingletonWrapper {
+
+    private static RepositoryManager instance;
+
+    public static void init(RepositoryManager repositoryManager) {
+        if (repositoryManager == null) {
+            throw new NullPointerException("RepositoryManager is null.");
+        }
+        instance = repositoryManager;
+    }
+
+    public static RepositoryManager getInstance() {
+        if (instance == null) {
+            throw new IllegalStateException("RepositoryManager has not been initialized yet.");
+        }
+        return instance;
+    }
+
+    public static void reInitialize() {
+        RepositoryManager rm = getInstance();
+        rm.reInitialize();
+    }
+}

--- a/52n-wps-server/src/main/java/org/n52/wps/server/RepositoryManagerSingletonWrapper.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/RepositoryManagerSingletonWrapper.java
@@ -57,9 +57,4 @@ public class RepositoryManagerSingletonWrapper {
         }
         return instance;
     }
-
-    public static void reInitialize() {
-        RepositoryManager rm = getInstance();
-        rm.reInitialize();
-    }
 }

--- a/52n-wps-server/src/main/java/org/n52/wps/server/WebProcessingService.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/WebProcessingService.java
@@ -29,8 +29,6 @@
 package org.n52.wps.server;
 
 // FvK: added Property Change Listener support
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -92,11 +90,14 @@ public class WebProcessingService implements ServletContextAware, ServletConfigA
     protected static Logger LOGGER = LoggerFactory.getLogger(WebProcessingService.class);
 
     private static String applicationBaseDir = null;
-    
+
     private ServletContext servletContext;
 
 	@Autowired
 	private ConfigurationManager configurationManager;
+
+    @Autowired
+    private RepositoryManager repositoryManager;
 
     public WebProcessingService() {
         LOGGER.info("NEW {}", this);
@@ -142,13 +143,13 @@ public class WebProcessingService implements ServletContextAware, ServletConfigA
     public void init() {
         LOGGER.info("*** WebProcessingService initializing... ***");
         WPSConfig conf = WPSConfig.getInstance(servletContext);
-        
+
         WPSConfig.getInstance().setConfigurationManager(configurationManager);
-        
+
         // this is important to set the lon lat support for correct CRS transformation.
         // TODO: Might be changed to an additional configuration parameter.
         System.setProperty("org.geotools.referencing.forceXY", "true");
-        
+
         try {
             if (conf == null) {
                 LOGGER.error("Initialization failed! Please look at the properties file!");
@@ -172,8 +173,8 @@ public class WebProcessingService implements ServletContextAware, ServletConfigA
         GeneratorFactory.initialize(generatorMap);
         LOGGER.info("Initialized {}", GeneratorFactory.getInstance());
 
-        RepositoryManager repoManager = RepositoryManager.getInstance();
-        LOGGER.info("Initialized {}", repoManager);
+        repositoryManager.init();
+        LOGGER.info("Initialized {}", repositoryManager);
 
         IDatabase database = DatabaseFactory.getDatabase();
         LOGGER.info("Initialized {}", database);
@@ -191,7 +192,7 @@ public class WebProcessingService implements ServletContextAware, ServletConfigA
         LOGGER.info("Service base url is {} | Service endpoint is {}",
                     conf.getServiceBaseUrl(),
                     conf.getServiceEndpoint());
-        
+
         LOGGER.info("*** WPS up and running! ***");
     }
 
@@ -207,7 +208,7 @@ public class WebProcessingService implements ServletContextAware, ServletConfigA
             OutputStream out = res.getOutputStream(); // closed by res.flushBuffer();
             RequestHandler handler = new RequestHandler(req.getParameterMap(), out);
             String mimeType = handler.getResponseMimeType();
-            requestedVersion = handler.getRequestedVersion();         
+            requestedVersion = handler.getRequestedVersion();
             res.setContentType(mimeType);
             handler.handle();
 
@@ -234,7 +235,7 @@ public class WebProcessingService implements ServletContextAware, ServletConfigA
         BufferedReader reader = null;
 
         String requestedVersion = null;
-        
+
         try {
             String contentType = req.getContentType();
             String characterEncoding = req.getCharacterEncoding();
@@ -353,6 +354,6 @@ public class WebProcessingService implements ServletContextAware, ServletConfigA
 
 	@Override
 	public void setServletContext(ServletContext servletContext) {
-		this.servletContext = servletContext;		
+		this.servletContext = servletContext;
 	}
 }

--- a/52n-wps-server/src/main/java/org/n52/wps/server/request/DescribeProcessRequest.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/request/DescribeProcessRequest.java
@@ -41,6 +41,7 @@ import net.opengis.wps.x100.ProcessDescriptionsDocument;
 import org.apache.commons.collections.map.CaseInsensitiveMap;
 import org.apache.xmlbeans.XmlCursor;
 import org.n52.wps.commons.WPSConfig;
+import org.n52.wps.server.RepositoryManagerSingletonWrapper;
 import org.n52.wps.server.ExceptionReport;
 import org.n52.wps.server.RepositoryManager;
 import org.n52.wps.server.WebProcessingService;
@@ -53,12 +54,12 @@ import org.w3c.dom.NodeList;
 
 /**
  * Handles a DescribeProcessRequest
- * @see Request  
+ * @see Request
  */
 public class DescribeProcessRequest extends Request {
 
 	private ProcessDescriptionsDocument document;
-	
+
 	/**
 	 * Creates a DescribeProcessRequest based on a Map (HTTP_GET)
 	 * @param ciMap The client input
@@ -67,7 +68,7 @@ public class DescribeProcessRequest extends Request {
 	public DescribeProcessRequest(CaseInsensitiveMap ciMap) throws ExceptionReport{
 		super(ciMap);
 	}
-	
+
 	/**
 	 * Creates a DescribeProcessRequest based on a Document (SOAP?)
 	 * @param doc The client input
@@ -75,28 +76,28 @@ public class DescribeProcessRequest extends Request {
 	 */
 	public DescribeProcessRequest(Document doc) throws ExceptionReport{
 		super(doc);
-		
+
 		//put the respective elements of the document in the map
 		NamedNodeMap nnm = doc.getFirstChild().getAttributes();
-		
+
 		map = new CaseInsensitiveMap();
-		
+
 		for (int i = 0; i < nnm.getLength(); i++) {
-			
+
 			Node n = nnm.item(i);
 			if(n.getLocalName().equalsIgnoreCase("service")){
 			map.put(n.getLocalName(), new String[]{n.getNodeValue()});
 			}else if(n.getLocalName().equalsIgnoreCase("version")){
-				map.put(n.getLocalName(), new String[]{n.getNodeValue()});				
+				map.put(n.getLocalName(), new String[]{n.getNodeValue()});
 			}
 		}
 		//get identifier
-		String identifierList = "";		
-		
+		String identifierList = "";
+
 		NodeList nList = doc.getFirstChild().getChildNodes();
-		
+
 		boolean identifierParameterExists = false;
-		
+
 		for (int i = 0; i < nList.getLength(); i++) {
 			Node n = nList.item(i);
 			if(n.getLocalName() != null && n.getLocalName().equalsIgnoreCase("identifier")){
@@ -111,7 +112,7 @@ public class DescribeProcessRequest extends Request {
 			map.put("identifier", new String[]{identifierList});
 		}
 	}
-	
+
 
 	/**
 	 * Validates the client input
@@ -119,15 +120,15 @@ public class DescribeProcessRequest extends Request {
 	 * @return True if the input is valid, False otherwise
 	 */
 	public boolean validate() throws ExceptionReport{
-		getMapValue("version", true, new String[]{"1.0.0"}); // required		
+		getMapValue("version", true, new String[]{"1.0.0"}); // required
 		getMapValue("identifier", true);  // required!
 		return true;
 	}
-	
+
 	public Object getAttachedResult(){
 		return document;
 	}
-	
+
 	/**
 	 * Actually serves the Request.
 	 * @throws ExceptionReport
@@ -135,50 +136,50 @@ public class DescribeProcessRequest extends Request {
 	 */
 	public Response call() throws ExceptionReport {
 		validate();
-		
+
 		document = ProcessDescriptionsDocument.Factory.newInstance();
 		document.addNewProcessDescriptions();
 		XmlCursor c = document.newCursor();
 		c.toFirstChild();
 		c.toLastAttribute();
 		c.setAttributeText(new QName(XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, "schemaLocation"), "http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsDescribeProcess_response.xsd");
-				
+
 		String[] identifiers = getMapValue("identifier", true).split(",");
 		document.getProcessDescriptions().setLang(WebProcessingService.DEFAULT_LANGUAGE);
 		document.getProcessDescriptions().setService("WPS");
 		document.getProcessDescriptions().setVersion("1.0.0");//FIXME set to requested version
-		
+
 		if(identifiers.length==1 && identifiers[0].equalsIgnoreCase("all")){
-			List<String> identifierList = RepositoryManager.getInstance().getAlgorithms();
+			List<String> identifierList = RepositoryManagerSingletonWrapper.getInstance().getAlgorithms();
 			identifiers = new String[identifierList.size()];
 			for(int i = 0;i<identifierList.size();i++){
 				identifiers[i] = identifierList.get(i);
 			}
 		}
-		
+
 //		if(identifiers.length == 0){
-//			throw new ExceptionReport("No process identifier specified for describe process operation.", 
-//					ExceptionReport.MISSING_PARAMETER_VALUE, 
+//			throw new ExceptionReport("No process identifier specified for describe process operation.",
+//					ExceptionReport.MISSING_PARAMETER_VALUE,
 //					"parameter: identifier");
-//		}else 
+//		}else
 		if(identifiers.length == 1){
 			if(identifiers[0] == null || identifiers[0].isEmpty()){
-				throw new ExceptionReport("Process description request with empty identifier.", 
-						ExceptionReport.INVALID_PARAMETER_VALUE, 
+				throw new ExceptionReport("Process description request with empty identifier.",
+						ExceptionReport.INVALID_PARAMETER_VALUE,
 						"identifier");
 			}
 		}
-		
+
 		for(String algorithmName : identifiers) {
-			if(!RepositoryManager.getInstance().containsAlgorithm(algorithmName)) {
-				throw new ExceptionReport("Algorithm does not exist: " + algorithmName, 
-											ExceptionReport.INVALID_PARAMETER_VALUE, 
+			if(!RepositoryManagerSingletonWrapper.getInstance().containsAlgorithm(algorithmName)) {
+				throw new ExceptionReport("Algorithm does not exist: " + algorithmName,
+											ExceptionReport.INVALID_PARAMETER_VALUE,
 											"identifier");
 			}
-			ProcessDescriptionType description = (ProcessDescriptionType) RepositoryManager.getInstance().getProcessDescription(algorithmName).getProcessDescriptionType(WPSConfig.VERSION_100);
+			ProcessDescriptionType description = (ProcessDescriptionType) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription(algorithmName).getProcessDescriptionType(WPSConfig.VERSION_100);
 			document.getProcessDescriptions().addNewProcessDescription().set(description);
 		}
-		
+
 		LOGGER.info("Handled Request successfully for: " + getMapValue("identifier", true));
 		return new DescribeProcessResponse(this);
 	}

--- a/52n-wps-server/src/main/java/org/n52/wps/server/request/DescribeProcessRequestV200.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/request/DescribeProcessRequestV200.java
@@ -40,6 +40,7 @@ import net.opengis.wps.x20.ProcessOfferingsDocument;
 import org.apache.commons.collections.map.CaseInsensitiveMap;
 import org.apache.xmlbeans.XmlCursor;
 import org.n52.wps.commons.WPSConfig;
+import org.n52.wps.server.RepositoryManagerSingletonWrapper;
 import org.n52.wps.server.ExceptionReport;
 import org.n52.wps.server.RepositoryManager;
 import org.n52.wps.server.response.DescribeProcessResponse;
@@ -51,12 +52,12 @@ import org.w3c.dom.NodeList;
 
 /**
  * Handles a DescribeProcessRequest
- * @see Request  
+ * @see Request
  */
 public class DescribeProcessRequestV200 extends Request {
 
 	private ProcessOfferingsDocument document;
-	
+
 	/**
 	 * Creates a DescribeProcessRequest based on a Map (HTTP_GET)
 	 * @param ciMap The client input
@@ -65,7 +66,7 @@ public class DescribeProcessRequestV200 extends Request {
 	public DescribeProcessRequestV200(CaseInsensitiveMap ciMap) throws ExceptionReport{
 		super(ciMap);
 	}
-	
+
 	/**
 	 * Creates a DescribeProcessRequest based on a Document
 	 * @param doc The client input
@@ -73,28 +74,28 @@ public class DescribeProcessRequestV200 extends Request {
 	 */
 	public DescribeProcessRequestV200(Document doc) throws ExceptionReport{
 		super(doc);
-		
+
 		//put the respective elements of the document in the map
 		NamedNodeMap nnm = doc.getFirstChild().getAttributes();
-		
+
 		map = new CaseInsensitiveMap();
-		
+
 		for (int i = 0; i < nnm.getLength(); i++) {
-			
+
 			Node n = nnm.item(i);
 			if(n.getLocalName().equalsIgnoreCase("service")){
 			map.put(n.getLocalName(), new String[]{n.getNodeValue()});
 			}else if(n.getLocalName().equalsIgnoreCase("version")){
-				map.put(n.getLocalName(), new String[]{n.getNodeValue()});				
+				map.put(n.getLocalName(), new String[]{n.getNodeValue()});
 			}
 		}
 		//get identifier
-		String identifierList = "";		
-		
+		String identifierList = "";
+
 		NodeList nList = doc.getFirstChild().getChildNodes();
-		
+
 		boolean identifierParameterExists = false;
-		
+
 		for (int i = 0; i < nList.getLength(); i++) {
 			Node n = nList.item(i);
 			if(n.getLocalName() != null && n.getLocalName().equalsIgnoreCase("identifier")){
@@ -109,7 +110,7 @@ public class DescribeProcessRequestV200 extends Request {
 			map.put("identifier", new String[]{identifierList});
 		}
 	}
-	
+
 
 	/**
 	 * Validates the client input
@@ -117,15 +118,15 @@ public class DescribeProcessRequestV200 extends Request {
 	 * @return True if the input is valid, False otherwise
 	 */
 	public boolean validate() throws ExceptionReport{
-		getMapValue("version", true, new String[]{WPSConfig.VERSION_200}); // required		
+		getMapValue("version", true, new String[]{WPSConfig.VERSION_200}); // required
 		getMapValue("identifier", true);  // required!
 		return true;
 	}
-	
+
 	public Object getAttachedResult(){
 		return document;
 	}
-	
+
 	/**
 	 * Actually serves the Request.
 	 * @throws ExceptionReport
@@ -133,18 +134,18 @@ public class DescribeProcessRequestV200 extends Request {
 	 */
 	public Response call() throws ExceptionReport {
 		validate();
-		
+
 		document = ProcessOfferingsDocument.Factory.newInstance();
 		document.addNewProcessOfferings();
 		XmlCursor c = document.newCursor();
 		c.toFirstChild();
 		c.toLastAttribute();
 		c.setAttributeText(new QName(XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, "schemaLocation"), "http://www.opengis.net/wps/2.0.0 http://schemas.opengis.net/wps/2.0.0/wpsDescribeProcess.xsd");
-				
+
 		String[] identifiers = getMapValue("identifier", true).split(",");
-		
+
 		if(identifiers.length==1 && identifiers[0].equalsIgnoreCase("all")){
-			List<String> identifierList = RepositoryManager.getInstance().getAlgorithms();
+			List<String> identifierList = RepositoryManagerSingletonWrapper.getInstance().getAlgorithms();
 			identifiers = new String[identifierList.size()];
 			for(int i = 0;i<identifierList.size();i++){
 				identifiers[i] = identifierList.get(i);
@@ -152,25 +153,25 @@ public class DescribeProcessRequestV200 extends Request {
 		}
 		if(identifiers.length == 1){
 			if(identifiers[0] == null || identifiers[0].isEmpty()){
-				throw new ExceptionReport("Process description request with empty identifier.", 
-						ExceptionReport.INVALID_PARAMETER_VALUE, 
+				throw new ExceptionReport("Process description request with empty identifier.",
+						ExceptionReport.INVALID_PARAMETER_VALUE,
 						"identifier");
 			}
 		}
-		
+
 		List<ProcessOffering> processOfferings = new ArrayList<>(identifiers.length);
-		
+
 		for(String algorithmName : identifiers) {
-			if(!RepositoryManager.getInstance().containsAlgorithm(algorithmName)) {
-				throw new ExceptionReport("Algorithm does not exist: " + algorithmName, 
-											ExceptionReport.INVALID_PARAMETER_VALUE, 
+			if(!RepositoryManagerSingletonWrapper.getInstance().containsAlgorithm(algorithmName)) {
+				throw new ExceptionReport("Algorithm does not exist: " + algorithmName,
+											ExceptionReport.INVALID_PARAMETER_VALUE,
 											"identifier");
 			}
-			ProcessOffering offering = (ProcessOffering) RepositoryManager.getInstance().getProcessDescription(algorithmName).getProcessDescriptionType(WPSConfig.VERSION_200);
+			ProcessOffering offering = (ProcessOffering) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription(algorithmName).getProcessDescriptionType(WPSConfig.VERSION_200);
 			processOfferings.add(offering);
 		}
 		document.getProcessOfferings().setProcessOfferingArray(processOfferings.toArray(new ProcessOffering[identifiers.length]));
-		
+
 		LOGGER.info("Handled Request successfully for: " + getMapValue("identifier", true));
 		return new DescribeProcessResponse(this);
 	}

--- a/52n-wps-server/src/main/java/org/n52/wps/server/request/ExecuteRequestV100.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/request/ExecuteRequestV100.java
@@ -72,6 +72,7 @@ import org.n52.wps.commons.context.ExecutionContextFactory;
 import org.n52.wps.io.data.IComplexData;
 import org.n52.wps.io.data.IData;
 import org.n52.wps.server.AbstractTransactionalAlgorithm;
+import org.n52.wps.server.RepositoryManagerSingletonWrapper;
 import org.n52.wps.server.ExceptionReport;
 import org.n52.wps.server.IAlgorithm;
 import org.n52.wps.server.RepositoryManager;
@@ -96,12 +97,12 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 	private ExecuteDocument execDom;
 	private Map<String, IData> returnResults;
 	private ExecuteResponseBuilderV100 execRespType;
-	
-	
+
+
 
 	/**
 	 * Creates an ExecuteRequest based on a Document (HTTP_POST)
-	 * 
+	 *
 	 * @param doc
 	 *            The clients submission
 	 * @throws ExceptionReport
@@ -127,7 +128,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 
 		// create an initial response
 		execRespType = new ExecuteResponseBuilderV100(this);
-        
+
         storeRequest(execDom);
 	}
 
@@ -147,9 +148,9 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 
         storeRequest(ciMap);
 	}
-	
+
 	public void getKVPDataInputs(){
-		
+
 	}
 
 	/**
@@ -164,7 +165,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 		this.execDom = ExecuteDocument.Factory.newInstance();
 		Execute execute = execDom.addNewExecute();
 		String processID = getMapValue("Identifier", true);
-		if (!RepositoryManager.getInstance().containsAlgorithm(processID)) {
+		if (!RepositoryManagerSingletonWrapper.getInstance().containsAlgorithm(processID)) {
 			throw new ExceptionReport("Process does not exist",
 					ExceptionReport.INVALID_PARAMETER_VALUE);
 		}
@@ -173,7 +174,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 		String dataInputString = getMapValue("DataInputs", true);
 		dataInputString = dataInputString.replace("&amp;","&");
 		String[] inputs = dataInputString.split(";");
-		
+
 		// Handle data inputs
 		for (String inputString : inputs) {
 			int position = inputString.indexOf("=");
@@ -193,8 +194,8 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 					value = inputString.substring(position + 1);
 				}
 			}
-			ProcessDescriptionType description = (ProcessDescriptionType) RepositoryManager.getInstance().getProcessDescription(processID).getProcessDescriptionType(WPSConfig.VERSION_100);
-			
+			ProcessDescriptionType description = (ProcessDescriptionType) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription(processID).getProcessDescriptionType(WPSConfig.VERSION_100);
+
 			if (description == null) {
 				throw new ExceptionReport("Data Identifier not supported: "
 						+ key, ExceptionReport.MISSING_PARAMETER_VALUE);
@@ -239,7 +240,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 					try {
 						attributeValue = URLDecoder.decode(attributeValue, "UTF-8");
 					} catch (UnsupportedEncodingException e) {
-						throw new ExceptionReport("Something went wrong while trying to decode value of " + attributeName, ExceptionReport.NO_APPLICABLE_CODE, e);						
+						throw new ExceptionReport("Something went wrong while trying to decode value of " + attributeName, ExceptionReport.NO_APPLICABLE_CODE, e);
 					}
 					if (attributeName.equalsIgnoreCase("encoding")) {
 						encodingAttribute = attributeValue;
@@ -281,9 +282,9 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 					// Handling ComplexData
 					else {
 						ComplexDataType data = input.addNewData().addNewComplexData();
-						
+
 						InputStream stream = new ByteArrayInputStream(value.getBytes());
-						
+
 						try {
 							data.set(XmlObject.Factory.parse(stream));
 						} catch (Exception e) {
@@ -296,7 +297,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 										ExceptionReport.NO_APPLICABLE_CODE, e1);
 							}
 						}
-						
+
 						if (schemaAttribute != null) {
 							data.setSchema(schemaAttribute);
 						}
@@ -307,7 +308,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 							data.setEncoding(encodingAttribute);
 						}
 					}
-				
+
 			} else if (inputDesc.isSetLiteralData()) {
 				LiteralDataType data = input.addNewData().addNewLiteralData();
 				if (value == null) {
@@ -325,7 +326,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 			} else if (inputDesc.isSetBoundingBoxData()) {
 				BoundingBoxType data = input.addNewData().addNewBoundingBoxData();
 				String[] values = value.split(",");
-				
+
 				if(values.length<4){
 					throw new ExceptionReport("Invalid Number of BBOX Values: "
 							+ inputDesc.getIdentifier().getStringValue(),
@@ -335,16 +336,16 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 				lowerCorner.add(values[0]);
 				lowerCorner.add(values[1]);
 				data.setLowerCorner(lowerCorner);
-				
+
 				List<String> upperCorner = new ArrayList<String>();
 				upperCorner.add(values[2]);
 				upperCorner.add(values[3]);
 				data.setUpperCorner(upperCorner);
-				
+
 				if(values.length>4){
 					data.setCrs(values[4]);
 				}
-				
+
 				if(values.length>5){
 					data.setDimensions(BigInteger.valueOf(Long.valueOf(values[5])));
 				}
@@ -379,7 +380,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 					outputDataInput = outputID;
 				}
 				outputDataInput = outputDataInput.replace("=", "");
-				ProcessDescriptionType description = (ProcessDescriptionType) RepositoryManager.getInstance().getProcessDescription(processID).getProcessDescriptionType(WPSConfig.VERSION_100);
+				ProcessDescriptionType description = (ProcessDescriptionType) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription(processID).getProcessDescriptionType(WPSConfig.VERSION_100);
 				OutputDescriptionType outputDesc = XMLBeansHelper
 						.findOutputByID(outputDataInput, description.getProcessOutputs()
 								.getOutputArray());
@@ -407,7 +408,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 					try{
 						attributeValue = URLDecoder.decode(attributeValue, "UTF-8");
 					} catch (UnsupportedEncodingException e) {
-						throw new ExceptionReport("Something went wrong while trying to decode value of " + attributeName, ExceptionReport.NO_APPLICABLE_CODE, e);						
+						throw new ExceptionReport("Something went wrong while trying to decode value of " + attributeName, ExceptionReport.NO_APPLICABLE_CODE, e);
 					}
 					if (attributeName.equalsIgnoreCase("mimeType")) {
 						output.setMimeType(attributeValue);
@@ -429,9 +430,9 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 			} else {
 				rawDataInput = rawData;
 			}
-			ProcessDescriptionType description = (ProcessDescriptionType) RepositoryManager.getInstance().getProcessDescription(processID).getProcessDescriptionType(WPSConfig.VERSION_100);
+			ProcessDescriptionType description = (ProcessDescriptionType) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription(processID).getProcessDescriptionType(WPSConfig.VERSION_100);
 			OutputDescriptionType outputDesc = XMLBeansHelper.findOutputByID(
-					rawDataInput, 
+					rawDataInput,
 							description.getProcessOutputs().getOutputArray());
 			if (outputDesc == null) {
 				throw new ExceptionReport(
@@ -458,7 +459,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 					try{
 						attributeValue = URLDecoder.decode(attributeValue, "UTF-8");
 					} catch (UnsupportedEncodingException e) {
-						throw new ExceptionReport("Something went wrong while trying to decode value of " + attributeName, ExceptionReport.NO_APPLICABLE_CODE, e);						
+						throw new ExceptionReport("Something went wrong while trying to decode value of " + attributeName, ExceptionReport.NO_APPLICABLE_CODE, e);
 					}
 					if (attributeName.equalsIgnoreCase("mimeType")) {
 						output.setMimeType(attributeValue);
@@ -482,14 +483,14 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 
 	/**
 	 * Validates the client request
-	 * 
+	 *
 	 * @return True if the input is valid, False otherwise
 	 */
 	public boolean validate() throws ExceptionReport {
 		// Identifier must be specified.
 		/*
 		 * Only for HTTP_GET: String identifier = getMapValue("identifier");
-		 * 
+		 *
 		 * try{ // Specifies if all complex valued output(s) of this process
 		 * should be stored by process // as web-accessible resources store =
 		 * getMapValue("store").equals("true");
@@ -503,7 +504,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 		 * 0) { throw new ExceptionReport("Incorrect number of arguments for
 		 * parameter dataInputs, please only a even number of parameter values",
 		 * ExceptionReport.INVALID_PARAMETER_VALUE); }
-		 * 
+		 *
 		 */
 		if (!WPSConfig.SUPPORTED_VERSIONS.contains(execDom.getExecute().getVersion())) {
 			throw new ExceptionReport("Specified version is not supported.",
@@ -513,15 +514,15 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 
 		//Fix for bug https://bugzilla.52north.org/show_bug.cgi?id=906
 		String identifier = getAlgorithmIdentifier();
-		
+
 		if(identifier == null){
 			throw new ExceptionReport(
 					"No process identifier supplied.",
-					ExceptionReport.MISSING_PARAMETER_VALUE, "identifier");			
+					ExceptionReport.MISSING_PARAMETER_VALUE, "identifier");
 		}
-		
+
 		// check if the algorithm is in our repository
-		if (!RepositoryManager.getInstance().containsAlgorithm(
+		if (!RepositoryManagerSingletonWrapper.getInstance().containsAlgorithm(
 				identifier)) {
 			throw new ExceptionReport(
 					"Specified process identifier does not exist",
@@ -530,7 +531,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 		}
 
 		// validate if the process can be executed
-		ProcessDescriptionType desc = (ProcessDescriptionType) RepositoryManager.getInstance().getProcessDescription(getAlgorithmIdentifier()).getProcessDescriptionType(WPSConfig.VERSION_100);
+		ProcessDescriptionType desc = (ProcessDescriptionType) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription(getAlgorithmIdentifier()).getProcessDescriptionType(WPSConfig.VERSION_100);
 		// We need a description of the inputs for the algorithm
 		if (desc == null) {
 			LOGGER.warn("desc == null");
@@ -538,17 +539,17 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 		}
 
 		// Get the inputdescriptions of the algorithm
-		
+
 		if(desc.getDataInputs()!=null){
 			InputDescriptionType[] inputDescs = desc.getDataInputs().getInputArray();
-		
+
 		//prevent NullPointerException for zero input values in execute request (if only default values are used)
 		InputType[] inputs;
 		if(getExecute().getDataInputs()==null)
 				inputs=new InputType[0];
 		else
 			inputs = getExecute().getDataInputs().getInputArray();
-			
+
 			// For each input supplied by the client
 			for (InputType input : inputs) {
 				boolean identifierMatched = false;
@@ -631,7 +632,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 
 	/**
 	 * Actually serves the Request.
-	 * 
+	 *
 	 * @throws ExceptionReport
 	 */
 	public Response call() throws ExceptionReport {
@@ -647,44 +648,44 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 			else {
 				context = new ExecutionContext();
 			}
-	
+
 				// register so that any function that calls ExecuteContextFactory.getContext() gets the instance registered with this thread
 			ExecutionContextFactory.registerContext(context);
-			
+
 			LOGGER.debug("started with execution");
-            
+
 			updateStatusStarted();
-            
+
 			// parse the input
 			InputType[] inputs = new InputType[0];
 			if( getExecute().getDataInputs()!=null){
 				inputs = getExecute().getDataInputs().getInputArray();
 			}
 			InputHandler parser = new InputHandler.Builder(new Input(inputs), getAlgorithmIdentifier()).build();
-			
+
 			// we got so far:
 			// get the algorithm, and run it with the clients input
-		
+
 			/*
 			 * IAlgorithm algorithm =
 			 * RepositoryManager.getInstance().getAlgorithm(getAlgorithmIdentifier());
 			 * returnResults = algorithm.run((Map)parser.getParsedInputLayers(),
 			 * (Map)parser.getParsedInputParameters());
 			 */
-			algorithm = RepositoryManager.getInstance().getAlgorithm(getAlgorithmIdentifier());
-			
+			algorithm = RepositoryManagerSingletonWrapper.getInstance().getAlgorithm(getAlgorithmIdentifier());
+
 			if(algorithm instanceof ISubject){
 				ISubject subject = (ISubject) algorithm;
 				subject.addObserver(this);
-				
+
 			}
-			
+
 			if(algorithm instanceof AbstractTransactionalAlgorithm){
 				returnResults = ((AbstractTransactionalAlgorithm)algorithm).run(execDom);
 			} else {
 				inputMap = parser.getParsedInputData();
 				returnResults = algorithm.run(inputMap);
-			} 
+			}
 
             List<String> errorList = algorithm.getErrors();
             if (errorList != null && !errorList.isEmpty()) {
@@ -739,15 +740,15 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
                 }
             }
 		}
-		
+
 		ExecuteResponse response = new ExecuteResponse(this);
         return response;
 	}
-    
+
 
 	/**
 	 * Gets the identifier of the algorithm the client requested
-	 * 
+	 *
 	 * @return An identifier
 	 */
 	public String getAlgorithmIdentifier() {
@@ -757,10 +758,10 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Gets the Execute that is associated with this Request
-	 * 
+	 *
 	 * @return The Execute
 	 */
 	public Execute getExecute() {
@@ -808,12 +809,12 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 		}
 	}
 
-	
+
 	public void update(ISubject subject) {
 		Object state = subject.getState();
 		LOGGER.info("Update received from Subject, state changed to : " + state);
 		StatusType status = StatusType.Factory.newInstance();
-		
+
 		int percentage = 0;
 		if (state instanceof Integer) {
 			percentage = (Integer) state;
@@ -823,25 +824,25 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 		}
 		updateStatus(status);
 	}
-    
+
 	public void updateStatusAccepted() {
 		StatusType status = StatusType.Factory.newInstance();
 		status.setProcessAccepted("Process Accepted");
 		updateStatus(status);
 	}
-	
+
 	public void updateStatusStarted() {
         StatusType status = StatusType.Factory.newInstance();
         status.addNewProcessStarted().setPercentCompleted(0);
         updateStatus(status);
     }
-	
+
     public void updateStatusSuccess() {
         StatusType status = StatusType.Factory.newInstance();
         status.setProcessSucceeded("Process successful");
         updateStatus(status);
-    }	
-    
+    }
+
     public void updateStatusError(String errorMessage) {
 		StatusType status = StatusType.Factory.newInstance();
 		net.opengis.ows.x11.ExceptionReportDocument.ExceptionReport excRep = status
@@ -852,7 +853,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
 		excType.setExceptionCode(ExceptionReport.NO_APPLICABLE_CODE);
 		updateStatus(status);
 	}
-	
+
 	private void updateStatus(StatusType status) {
 		getExecuteResponseBuilder().setStatus(status);
         try {
@@ -873,7 +874,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
             throw new RuntimeException(e);
         }
 	}
-    
+
     private void storeRequest(ExecuteDocument executeDocument) {
         InputStream is = null;
         try {
@@ -886,9 +887,9 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
             IOUtils.closeQuietly(is);
         }
     }
-    
+
     private void storeRequest(CaseInsensitiveMap map) {
-  
+
         BufferedWriter w = null;
         ByteArrayOutputStream os = null;
         ByteArrayInputStream is = null;
@@ -897,7 +898,7 @@ public class ExecuteRequestV100 extends ExecuteRequest implements IObserver  {
             w = new BufferedWriter(new OutputStreamWriter(os));
             for (Object key : map.keySet()) {
                 Object value = map.get(key);
-                String valueString = "";                
+                String valueString = "";
                 if(value instanceof String[]){
                 	valueString = ((String[])value)[0];
                 }else{

--- a/52n-wps-server/src/main/java/org/n52/wps/server/request/ExecuteRequestV200.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/request/ExecuteRequestV200.java
@@ -46,6 +46,7 @@ import org.n52.wps.commons.context.ExecutionContext;
 import org.n52.wps.commons.context.ExecutionContextFactory;
 import org.n52.wps.io.data.IComplexData;
 import org.n52.wps.io.data.IData;
+import org.n52.wps.server.RepositoryManagerSingletonWrapper;
 import org.n52.wps.server.ExceptionReport;
 import org.n52.wps.server.IAlgorithm;
 import org.n52.wps.server.RepositoryManager;
@@ -73,7 +74,7 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 
 	/**
 	 * Creates an ExecuteRequest based on a Document (HTTP_POST)
-	 * 
+	 *
 	 * @param doc
 	 *            The clients submission
 	 * @throws ExceptionReport
@@ -105,7 +106,7 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 
 	/**
 	 * Validates the client request
-	 * 
+	 *
 	 * @return True if the input is valid, False otherwise
 	 */
 	public boolean validate() throws ExceptionReport {
@@ -126,7 +127,7 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 		}
 
 		// check if the algorithm is in our repository
-		if (!RepositoryManager.getInstance().containsAlgorithm(identifier)) {
+		if (!RepositoryManagerSingletonWrapper.getInstance().containsAlgorithm(identifier)) {
 			throw new ExceptionReport(
 					"Specified process identifier does not exist",
 					ExceptionReport.INVALID_PARAMETER_VALUE, "identifier="
@@ -134,7 +135,7 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 		}
 
 		// validate if the process can be executed
-		ProcessOffering desc = (ProcessOffering) RepositoryManager
+		ProcessOffering desc = (ProcessOffering) RepositoryManagerSingletonWrapper
 				.getInstance().getProcessDescription(getAlgorithmIdentifier())
 				.getProcessDescriptionType(WPSConfig.VERSION_200);
 		// We need a description of the inputs for the algorithm
@@ -144,16 +145,16 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 		}
 
 	    //TODO validate in-/outputs
-		
+
 		//TODO check for null
 		rawData = execDom.getExecute().getResponse().equals(ExecuteRequestType.Response.RAW);
-		
+
 		return true;
 	}
-	
+
 	/**
 	 * Gets the Execute that is associated with this Request
-	 * 
+	 *
 	 * @return The Execute
 	 */
 	public ExecuteRequestType getExecute() {
@@ -162,7 +163,7 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 
 	/**
 	 * Actually serves the Request.
-	 * 
+	 *
 	 * @throws ExceptionReport
 	 */
 	public Response call() throws ExceptionReport {
@@ -171,7 +172,7 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 		try {
 			//TODO add outputs to execution context
 			ExecutionContext context = new ExecutionContext();
-			
+
 			// register so that any function that calls
 			// ExecuteContextFactory.getContext() gets the instance registered
 			// with this thread
@@ -191,8 +192,8 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 
 			// we got so far:
 			// get the algorithm, and run it with the clients input
-			
-			algorithm = RepositoryManager.getInstance().getAlgorithm(
+
+			algorithm = RepositoryManagerSingletonWrapper.getInstance().getAlgorithm(
 					getAlgorithmIdentifier());
 
 			if (algorithm instanceof ISubject) {
@@ -201,7 +202,7 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 			}
 
 			inputMap = parser.getParsedInputData();
-			returnResults = algorithm.run(inputMap);			
+			returnResults = algorithm.run(inputMap);
 
 			List<String> errorList = algorithm.getErrors();
 			if (errorList != null && !errorList.isEmpty()) {
@@ -270,7 +271,7 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 
 	/**
 	 * Gets the identifier of the algorithm the client requested
-	 * 
+	 *
 	 * @return An identifier
 	 */
 	public String getAlgorithmIdentifier() {
@@ -296,7 +297,7 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 	public void update(ISubject subject) {
 		Object state = subject.getState();
 		LOGGER.info("Update received from Subject, state changed to : " + state);
-		
+
 		StatusInfo status = StatusInfo.Factory.newInstance();
 
 		int percentage = 0;
@@ -308,25 +309,25 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 		updateStatus(status);
 	}
 
-	public void updateStatusAccepted() {		
+	public void updateStatusAccepted() {
 		StatusInfo status = StatusInfo.Factory.newInstance();
 		status.setStatus(ExecuteResponseBuilderV200.Status.Accepted.toString());
 		updateStatus(status);
 	}
 
-	public void updateStatusSuccess() {		
+	public void updateStatusSuccess() {
 		StatusInfo status = StatusInfo.Factory.newInstance();
 		status.setStatus(ExecuteResponseBuilderV200.Status.Succeeded.toString());
 		updateStatus(status);
 	}
 
-	public void updateStatusFailed() {		
+	public void updateStatusFailed() {
 		StatusInfo status = StatusInfo.Factory.newInstance();
 		status.setStatus(ExecuteResponseBuilderV200.Status.Failed.toString());
 		updateStatus(status);
 	}
 
-	public void updateStatusStarted() {		
+	public void updateStatusStarted() {
 		StatusInfo status = StatusInfo.Factory.newInstance();
 		status.setStatus(ExecuteResponseBuilderV200.Status.Running.toString());
 		status.setPercentCompleted(0);
@@ -374,6 +375,6 @@ public class ExecuteRequestV200 extends ExecuteRequest implements IObserver {
 
 	@Override
 	public void updateStatusError(String errorMessage) {
-		// TODO Auto-generated method stub		
+		// TODO Auto-generated method stub
 	}
 }

--- a/52n-wps-server/src/main/java/org/n52/wps/server/request/InputHandler.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/request/InputHandler.java
@@ -91,6 +91,7 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Node;
 
 import com.google.common.primitives.Doubles;
+import org.n52.wps.server.RepositoryManagerSingletonWrapper;
 
 /**
  * Handles the input of the client and stores it into a Map.
@@ -142,8 +143,8 @@ public class InputHandler {
 	 */
         private InputHandler(Builder builder) throws ExceptionReport {
 		this.algorithmIdentifier = builder.algorithmIdentifier;
-		this.processDesc = (ProcessDescriptionType) RepositoryManager.getInstance().getProcessDescription(algorithmIdentifier).getProcessDescriptionType(WPSConfig.VERSION_100);
-		this.processOffering = (ProcessOffering) RepositoryManager.getInstance().getProcessDescription(algorithmIdentifier).getProcessDescriptionType(WPSConfig.VERSION_200);
+		this.processDesc = (ProcessDescriptionType) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription(algorithmIdentifier).getProcessDescriptionType(WPSConfig.VERSION_100);
+		this.processOffering = (ProcessOffering) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription(algorithmIdentifier).getProcessDescriptionType(WPSConfig.VERSION_200);
 
 		if (processDesc == null) {
                     throw new ExceptionReport("Error while accessing the process description for " + algorithmIdentifier,
@@ -153,11 +154,11 @@ public class InputHandler {
 		Map<String, InterceptorInstance> inputInterceptors = resolveInputInterceptors(algorithmIdentifier);
 
 		InputType[] inputsV100 = builder.inputs.getInputsV100();
-		
+
 		DataInputType[] inputsV200 = builder.inputs.getInputsV200();
-		
+
 		if(inputsV100 != null){
-		
+
 		for (InputType input : inputsV100) {
 			String inputId = input.getIdentifier().getStringValue().trim();
 			if (inputInterceptors.containsKey(inputId)) {
@@ -190,7 +191,7 @@ public class InputHandler {
 			}
 		}
 		}else if(inputsV200 != null){
-			
+
 			for (DataInputType input : inputsV200) {
 				String inputId = input.getId().trim();
 				if (inputInterceptors.containsKey(inputId)) {
@@ -204,11 +205,11 @@ public class InputHandler {
 				}
 
 				if(input.getData() != null) {
-					
+
 					net.opengis.wps.x20.InputDescriptionType inputDescription = XMLBeansHelper.findInputByID(inputId, processOffering.getProcess());
-					
+
 					DataDescriptionType dataDesc = inputDescription.getDataDescription();
-					
+
 					if(dataDesc instanceof net.opengis.wps.x20.ComplexDataType) {
 						handleComplexData(input, inputId);
 					}
@@ -228,7 +229,7 @@ public class InputHandler {
 				}
 			}
 		}
-		
+
 	}
 
     Map<String, InterceptorInstance> resolveInputInterceptors(String algorithmClassName) {
@@ -554,7 +555,7 @@ public class InputHandler {
 					" mimeType: " + dataMimeType +
 					" encoding: " + formatEncoding);
 
-			Class<?> algorithmInput = RepositoryManager.getInstance().getInputDataTypeForAlgorithm(this.algorithmIdentifier, inputId);
+			Class<?> algorithmInput = RepositoryManagerSingletonWrapper.getInstance().getInputDataTypeForAlgorithm(this.algorithmIdentifier, inputId);
 			parser = ParserFactory.getInstance().getParser(formatSchema, dataMimeType, formatEncoding, algorithmInput);
 		} catch (RuntimeException e) {
 			throw new ExceptionReport("Error obtaining input data", ExceptionReport.NO_APPLICABLE_CODE, e);
@@ -610,11 +611,11 @@ public class InputHandler {
              return result;
          }
 
-         
+
 	/**
 	 * Handles the complexValue, which in this case should always include XML
 	 * which can be parsed into a FeatureCollection.
-	 * 
+	 *
 	 * @param input
 	 *            The client input
 	 * @param inputId
@@ -687,11 +688,11 @@ public class InputHandler {
 				formatSchema = format.getSchema();
 			}
 		} else {
-			
+
 			Format[] formatArray =  inputReferenceDesc.getDataDescription().getFormatArray();
-			
+
 			Format defaultFormat = getDefaultFormat(formatArray);
-			
+
 			// mimeType not in request
 			if (StringUtils.isBlank(dataMimeType) && !data.isSetEncoding()
 					&& !data.isSetSchema()) {
@@ -838,7 +839,7 @@ public class InputHandler {
 									 * NullPointerException if one of the
 									 * supported types is given by mimetype and
 									 * not by schema:
-									 * 
+									 *
 									 * old code:
 									 * if(tempFormat.getEncoding().equalsIgnoreCase
 									 * (data.getSchema())){
@@ -890,7 +891,7 @@ public class InputHandler {
 					+ formatSchema + " mimeType: " + dataMimeType
 					+ " encoding: " + formatEncoding);
 
-			Class<?> algorithmInput = RepositoryManager.getInstance()
+			Class<?> algorithmInput = RepositoryManagerSingletonWrapper.getInstance()
 					.getInputDataTypeForAlgorithm(this.algorithmIdentifier,
 							inputId);
 			parser = ParserFactory.getInstance().getParser(formatSchema,
@@ -917,10 +918,10 @@ public class InputHandler {
 		list.add(collection);
 		inputData.put(inputId, list);
 	}
-	
+
 	/**
 	 * Handles the ComplexValueReference
-	 * 
+	 *
 	 * @param input
 	 *            The client input
 	 * @throws ExceptionReport
@@ -1413,7 +1414,7 @@ public class InputHandler {
 
 		IParser parser = null;
 		try {
-			Class<?> algorithmInputClass = RepositoryManager.getInstance()
+			Class<?> algorithmInputClass = RepositoryManagerSingletonWrapper.getInstance()
 					.getInputDataTypeForAlgorithm(this.algorithmIdentifier,
 							inputID);
 			if (algorithmInputClass == null) {
@@ -1454,9 +1455,9 @@ public class InputHandler {
 		}
 
 	}
-	
+
 	private Format getDefaultFormat(Format[] formatArray){
-		
+
 		for (Format format : formatArray) {
 			if(format.isSetDefault()){
 				return format;
@@ -1465,17 +1466,17 @@ public class InputHandler {
 		//TODO throw RuntimeException, as there must be a default format?
 		return null;
 	}
-	
+
 	private Format findFormat(net.opengis.wps.x20.InputDescriptionType inputReferenceDesc,
 			String dataMimeType, String dataSchema, String dataEncoding,
 			String potentialFormatSchema, String potentialFormatEncoding) {
 		Format result = null;
 		boolean canUseDefault = false;
-		
+
 		Format[] formatArray =  inputReferenceDesc.getDataDescription().getFormatArray();
-		
+
 		Format defaultFormat = getDefaultFormat(formatArray);
-		
+
 		String defaultMimeType = defaultFormat.getMimeType();
 
 		if (defaultMimeType.equalsIgnoreCase(dataMimeType)) {
@@ -1509,7 +1510,7 @@ public class InputHandler {
 		}
 		return result;
 	}
-	
+
 	private Format getNonDefaultFormat(
 			net.opengis.wps.x20.InputDescriptionType inputRefDesc, String dataMimeType,
 			String dataSchema, String dataEncoding) {
@@ -1548,7 +1549,7 @@ public class InputHandler {
 		}
 		return null;
 	}
-	
+
          protected IData parseComplexValue(String formatEncoding, String complexValue, String dataMimeType, String formatSchema, IParser parser) throws ExceptionReport {
              IData idata;
              String complexValueCopy = complexValue.toString();
@@ -1700,13 +1701,13 @@ public class InputHandler {
 		}
 
 		net.opengis.wps.x20.InputDescriptionType inputDesc = XMLBeansHelper.findInputByID(inputID, processOffering.getProcess());
-				
+
 		LiteralDataDomain literalDataDomain = ((LiteralDataType)inputDesc.getDataDescription()).getLiteralDataDomainArray(0);
-		
-		
+
+
 		net.opengis.ows.x20.DomainMetadataType dataType = literalDataDomain.getDataType();
 		String xmlDataType = dataType != null ? dataType.getReference() : null;
-		
+
 		//still null, assume string as default
 		if(xmlDataType == null) {
 			xmlDataType = BasicXMLTypeFactory.STRING_URI;
@@ -1767,7 +1768,7 @@ public class InputHandler {
 		}
 
 	}
-	
+
 	private boolean checkRange(IData parameterObj, RangeType allowedRange){
 
 		List<?> l = allowedRange.getRangeClosure();
@@ -1887,7 +1888,7 @@ public class InputHandler {
 
 		return false;
 	}
-	
+
 	/**
 	 * Handles the ComplexValueReference
 	 * @param input The client input
@@ -2270,7 +2271,7 @@ public class InputHandler {
 
 		IParser parser = null;
 		try {
-			Class<?> algorithmInputClass = RepositoryManager.getInstance().getInputDataTypeForAlgorithm(this.algorithmIdentifier, inputID);
+			Class<?> algorithmInputClass = RepositoryManagerSingletonWrapper.getInstance().getInputDataTypeForAlgorithm(this.algorithmIdentifier, inputID);
 			if(algorithmInputClass == null) {
 				throw new RuntimeException("Could not determine internal input class for input" + inputID);
 			}
@@ -2406,14 +2407,14 @@ public class InputHandler {
 	 */
     private void handleBBoxValue(DataInputType input)
             throws ExceptionReport {
-    	
+
     	net.opengis.ows.x20.BoundingBoxType boundingBoxType = null;
 		try {
 			boundingBoxType = net.opengis.ows.x20.BoundingBoxType.Factory.parse(input.getData().getDomNode());
 		} catch (XmlException e) {
 			LOGGER.error("XmlException occurred while trying to parse bounding box: " + (boundingBoxType == null ? null : boundingBoxType.toString()), e);
 		}
-    	
+
         IData envelope = parseBoundingBox(boundingBoxType);
 
         List<IData> resultList = inputData.get(input.getId());
@@ -2467,7 +2468,7 @@ public class InputHandler {
         }
         return new BoundingBoxData(lower, upper, bbt.getCrs());
     }
-    
+
     private double[] parseCoordinate(List<?> ordinates)
             throws NumberFormatException {
         List<Number> coordinate = new ArrayList<Number>(ordinates.size());

--- a/52n-wps-server/src/main/java/org/n52/wps/server/response/ExecuteResponseBuilderV100.java
+++ b/52n-wps-server/src/main/java/org/n52/wps/server/response/ExecuteResponseBuilderV100.java
@@ -50,6 +50,7 @@ import org.apache.xmlbeans.XmlObject;
 import org.n52.wps.commons.WPSConfig;
 import org.n52.wps.io.data.IBBOXData;
 import org.n52.wps.io.data.IData;
+import org.n52.wps.server.RepositoryManagerSingletonWrapper;
 import org.n52.wps.server.ExceptionReport;
 import org.n52.wps.server.ProcessDescription;
 import org.n52.wps.server.RepositoryManager;
@@ -97,7 +98,7 @@ public class ExecuteResponseBuilderV100 implements ExecuteResponseBuilder{
 		this.identifier = request.getExecute().getIdentifier().getStringValue().trim();
 		ExecuteResponse responseElem = doc.getExecuteResponse();
 		responseElem.addNewProcess().addNewIdentifier().setStringValue(identifier);
-		superDescription = RepositoryManager.getInstance().getProcessDescription(this.identifier);
+		superDescription = RepositoryManagerSingletonWrapper.getInstance().getProcessDescription(this.identifier);
 		description = (ProcessDescriptionType) superDescription.getProcessDescriptionType(WPSConfig.VERSION_100);
 		if(description==null){
 			throw new RuntimeException("Error while accessing the process description for "+ identifier);
@@ -186,7 +187,7 @@ public class ExecuteResponseBuilderV100 implements ExecuteResponseBuilder{
 
 				// THIS IS A WORKAROUND AND ACTUALLY NOT COMPLIANT TO THE SPEC.
 
-				ProcessDescriptionType description = (ProcessDescriptionType) RepositoryManager.getInstance().getProcessDescription(request.getExecute().getIdentifier().getStringValue()).getProcessDescriptionType(WPSConfig.VERSION_100);
+				ProcessDescriptionType description = (ProcessDescriptionType) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription(request.getExecute().getIdentifier().getStringValue()).getProcessDescriptionType(WPSConfig.VERSION_100);
 				if(description==null){
 					throw new RuntimeException("Error while accessing the process description for "+ request.getExecute().getIdentifier().getStringValue());
 				}
@@ -378,12 +379,12 @@ public class ExecuteResponseBuilderV100 implements ExecuteResponseBuilder{
 	}
 
 	public void setStatus(XmlObject statusObject) {
-		
+
 		if(statusObject instanceof StatusType){
 			StatusType status = (StatusType)statusObject;
 			//workaround, should be generated either at the creation of the document or when the process has been finished.
 			status.setCreationTime(creationTime);
-			doc.getExecuteResponse().setStatus(status);		
+			doc.getExecuteResponse().setStatus(status);
 		}else{
 			LOGGER.warn(String.format("XMLObject not of type \"net.opengis.wps.x100.StatusType\", but {}. Cannot not set status. ", statusObject.getClass()));
 		}

--- a/52n-wps-server/src/test/java/org/n52/wps/server/CapabilitiesGetProcessDescriptionExceptionTest.java
+++ b/52n-wps-server/src/test/java/org/n52/wps/server/CapabilitiesGetProcessDescriptionExceptionTest.java
@@ -47,40 +47,41 @@ import org.n52.wps.webapp.common.AbstractITClass;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 public class CapabilitiesGetProcessDescriptionExceptionTest extends AbstractITClass {
-	
-	public static final String IDENTIFIER = "CatchMeIfYouCan";	
+
+	public static final String IDENTIFIER = "CatchMeIfYouCan";
 	public static boolean algorithmTriedToInstantiate;
 
 	@Before
     public void setUp(){
-		MockMvcBuilders.webAppContextSetup(this.wac).build();
-		WPSConfig.getInstance().setConfigurationManager(this.wac.getBean(ConfigurationManager.class));
+        RepositoryManager repositoryManager = new RepositoryManager();
+        repositoryManager.setApplicationContext(this.wac);
+        repositoryManager.init();
     }
-	
+
 	@Test
 	public void shouldIgnoreExceptionousProcess() throws XmlException, IOException {
 //		MockUtil.getMockConfig();
 		CapabilitiesDocument caps = CapabilitiesConfiguration.getInstance(CapabilitiesDocument.Factory.newInstance());
-		
+
 		Assert.assertTrue("Erroneous algorithm was never instantiated!", algorithmTriedToInstantiate);
-		
+
 		boolean found = false;
 		for (ProcessBriefType pbt : caps.getCapabilities().getProcessOfferings().getProcessArray()) {
 			if (IDENTIFIER.equals(pbt.getIdentifier().getStringValue())) {
 				found = true;
 			}
 		}
-		
+
 		Assert.assertFalse("Algo found but was not expected!", found);
 	}
 
 	@Algorithm(version = "0.1", identifier = CapabilitiesGetProcessDescriptionExceptionTest.IDENTIFIER)
 	public static class InstantiationExceptionAlgorithm extends AbstractAnnotatedAlgorithm {
-		
+
 		public InstantiationExceptionAlgorithm() {
 			CapabilitiesGetProcessDescriptionExceptionTest.algorithmTriedToInstantiate = true;
 		}
-		
+
 		private String output;
 
 		@LiteralDataInput(identifier = "input")
@@ -95,12 +96,12 @@ public class CapabilitiesGetProcessDescriptionExceptionTest extends AbstractITCl
 		public void thisMethodsWillNeverEverByCalled() {
 			this.output = "w0000t";
 		}
-		
+
 		@Override
 		public synchronized ProcessDescription getDescription() {
 			throw new RuntimeException("Gotcha!");
 		}
 
-		
+
 	}
 }

--- a/52n-wps-server/src/test/java/org/n52/wps/server/request/ExecuteRequestTest.java
+++ b/52n-wps-server/src/test/java/org/n52/wps/server/request/ExecuteRequestTest.java
@@ -49,6 +49,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.n52.wps.server.ExceptionReport;
+import org.n52.wps.server.RepositoryManager;
 import org.n52.wps.server.database.DatabaseFactory;
 import org.n52.wps.server.request.ExecuteRequestV100;
 import org.n52.wps.webapp.common.AbstractITClass;
@@ -76,6 +77,10 @@ public class ExecuteRequestTest extends AbstractITClass {
 
 		fac = DocumentBuilderFactory.newInstance();
 		fac.setNamespaceAware(true);
+
+        RepositoryManager repositoryManager = new RepositoryManager();
+        repositoryManager.setApplicationContext(this.wac);
+        repositoryManager.init();
     }
 
 	@Test

--- a/52n-wps-server/src/test/java/org/n52/wps/server/request/ExecuteRequestTest.java
+++ b/52n-wps-server/src/test/java/org/n52/wps/server/request/ExecuteRequestTest.java
@@ -76,7 +76,6 @@ public class ExecuteRequestTest extends AbstractITClass {
 
 		fac = DocumentBuilderFactory.newInstance();
 		fac.setNamespaceAware(true);
-		MockMvcBuilders.webAppContextSetup(this.wac).build();
     }
 
 	@Test

--- a/52n-wps-server/src/test/java/org/n52/wps/server/request/InputHandlerTest.java
+++ b/52n-wps-server/src/test/java/org/n52/wps/server/request/InputHandlerTest.java
@@ -55,14 +55,16 @@ import org.junit.Test;
 import org.n52.wps.commons.WPSConfig;
 import org.n52.wps.server.ExceptionReport;
 import org.n52.wps.server.RepositoryManager;
+import org.n52.wps.server.RepositoryManagerSingletonWrapper;
 import org.n52.wps.server.handler.DataInputInterceptors.InterceptorInstance;
 import org.n52.wps.util.XMLBeansHelper;
+import org.n52.wps.webapp.common.AbstractITClass;
 
 /**
  *
  * @author isuftin
  */
-public class InputHandlerTest {
+public class InputHandlerTest extends AbstractITClass {
 
     private static File simpleBufferAlgorithmFile = null;
     private static File dummyTestClassAlgorithmFile = null;
@@ -84,6 +86,10 @@ public class InputHandlerTest {
         dummyTestClassAlgorithmFile = new File("src/test/resources/DummyTestClass.xml");
         dummyTestClassAlgorithmExecDoc = ExecuteDocument.Factory.parse(dummyTestClassAlgorithmFile);
         dummyTestClassAlgorithmInputArray = dummyTestClassAlgorithmExecDoc.getExecute().getDataInputs().getInputArray();
+
+        RepositoryManager repositoryManager = new RepositoryManager();
+        repositoryManager.setApplicationContext(this.wac);
+        repositoryManager.init();
     }
 
     @After
@@ -116,9 +122,9 @@ public class InputHandlerTest {
         System.out.println("Testing testInputHandlerResolveInputDescriptionTypes...");
 
         new InputHandler.Builder(new Input(simpleBufferAlgorithmInputArray), "org.n52.wps.server.algorithm.SimpleBufferAlgorithm").build();
-        
-        ProcessDescriptionType processDescriptionType = (ProcessDescriptionType) RepositoryManager.getInstance().getProcessDescription("org.n52.wps.server.algorithm.SimpleBufferAlgorithm").getProcessDescriptionType(WPSConfig.VERSION_100);
-                
+
+        ProcessDescriptionType processDescriptionType = (ProcessDescriptionType) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription("org.n52.wps.server.algorithm.SimpleBufferAlgorithm").getProcessDescriptionType(WPSConfig.VERSION_100);
+
         InputDescriptionType idt = XMLBeansHelper.findInputByID("data", processDescriptionType.getDataInputs());
         assertThat(idt, is(notNullValue()));
         assertThat(idt.getMaxOccurs().intValue(), equalTo(1));
@@ -126,8 +132,8 @@ public class InputHandlerTest {
 
         new InputHandler.Builder(new Input(dummyTestClassAlgorithmInputArray), "org.n52.wps.server.algorithm.test.DummyTestClass").build();
 
-        processDescriptionType = (ProcessDescriptionType) RepositoryManager.getInstance().getProcessDescription("org.n52.wps.server.algorithm.test.DummyTestClass").getProcessDescriptionType(WPSConfig.VERSION_100);
-                
+        processDescriptionType = (ProcessDescriptionType) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription("org.n52.wps.server.algorithm.test.DummyTestClass").getProcessDescriptionType(WPSConfig.VERSION_100);
+
         idt = XMLBeansHelper.findInputByID("BBOXInputData", processDescriptionType.getDataInputs());
         assertThat(idt, is(notNullValue()));
         assertThat(idt.getMaxOccurs().intValue(), equalTo(1));
@@ -139,8 +145,8 @@ public class InputHandlerTest {
         System.out.println("Testing testInputHandlerGetNonDefaultFormat...");
 
         InputHandler instance = new InputHandler.Builder(new Input(simpleBufferAlgorithmInputArray), "org.n52.wps.server.algorithm.SimpleBufferAlgorithm").build();
-        ProcessDescriptionType processDescriptionType = (ProcessDescriptionType) RepositoryManager.getInstance().getProcessDescription("org.n52.wps.server.algorithm.SimpleBufferAlgorithm").getProcessDescriptionType(WPSConfig.VERSION_100);
-        
+        ProcessDescriptionType processDescriptionType = (ProcessDescriptionType) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription("org.n52.wps.server.algorithm.SimpleBufferAlgorithm").getProcessDescriptionType(WPSConfig.VERSION_100);
+
         InputDescriptionType idt = XMLBeansHelper.findInputByID("data", processDescriptionType.getDataInputs());
         String dataMimeType = "text/xml; subtype=gml/3.1.0";
         String dataSchema = "http://schemas.opengis.net/gml/3.1.0/base/feature.xsd";
@@ -152,13 +158,13 @@ public class InputHandlerTest {
         assertThat(cddt.getSchema(), is(equalTo("http://schemas.opengis.net/gml/3.1.0/base/feature.xsd")));
 
         instance = new InputHandler.Builder(new Input(dummyTestClassAlgorithmInputArray), "org.n52.wps.server.algorithm.test.DummyTestClass").build();
-        processDescriptionType = (ProcessDescriptionType) RepositoryManager.getInstance().getProcessDescription("org.n52.wps.server.algorithm.test.DummyTestClass").getProcessDescriptionType(WPSConfig.VERSION_100);
-        
+        processDescriptionType = (ProcessDescriptionType) RepositoryManagerSingletonWrapper.getInstance().getProcessDescription("org.n52.wps.server.algorithm.test.DummyTestClass").getProcessDescriptionType(WPSConfig.VERSION_100);
+
         idt = XMLBeansHelper.findInputByID("BBOXInputData", processDescriptionType.getDataInputs());
         cddt = instance.getNonDefaultFormat(idt, dataMimeType, dataSchema, dataEncoding);
         assertThat(cddt, is(nullValue()));
     }
-    
+
     @Test
     public void testInputHandlerGetComplexValueNodeString() throws ExceptionReport, XmlException, IOException {
         System.out.println("Testing testInputHandlerGetComplexValueNodeString...");

--- a/52n-wps-server/src/test/java/org/n52/wps/server/request/SimpleBufferAlgorithmInputHandlerTest.java
+++ b/52n-wps-server/src/test/java/org/n52/wps/server/request/SimpleBufferAlgorithmInputHandlerTest.java
@@ -53,6 +53,7 @@ import org.junit.Test;
 import org.n52.wps.commons.WPSConfig;
 import org.n52.wps.io.data.IData;
 import org.n52.wps.server.ExceptionReport;
+import org.n52.wps.server.RepositoryManager;
 import org.n52.wps.webapp.api.ConfigurationManager;
 import org.n52.wps.webapp.common.AbstractITClass;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -61,7 +62,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
  *
  * @author isuftin
  */
-public class SimpleBufferAlgorithmInputHandlerTest extends AbstractITClass{
+public class SimpleBufferAlgorithmInputHandlerTest extends AbstractITClass {
 
     private static String sampleFileName = null;
     private static File sampleFile = null;
@@ -83,8 +84,9 @@ public class SimpleBufferAlgorithmInputHandlerTest extends AbstractITClass{
 
     @Before
     public void setUp() throws XmlException, IOException {
-		MockMvcBuilders.webAppContextSetup(this.wac).build();
-		WPSConfig.getInstance().setConfigurationManager(this.wac.getBean(ConfigurationManager.class));
+        RepositoryManager repositoryManager = new RepositoryManager();
+        repositoryManager.setApplicationContext(this.wac);
+        repositoryManager.init();
     }
 
     @After

--- a/52n-wps-server/src/test/java/org/n52/wps/server/response/ExecuteResponseBuilderTest.java
+++ b/52n-wps-server/src/test/java/org/n52/wps/server/response/ExecuteResponseBuilderTest.java
@@ -45,6 +45,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.n52.wps.commons.WPSConfig;
+import org.n52.wps.server.RepositoryManagerSingletonWrapper;
+import org.n52.wps.server.RepositoryManager;
 import org.n52.wps.server.request.ExecuteRequestV100;
 import org.n52.wps.webapp.api.ConfigurationManager;
 import org.n52.wps.webapp.common.AbstractITClass;
@@ -75,8 +77,9 @@ public class ExecuteResponseBuilderTest extends AbstractITClass{
 
 		fac = DocumentBuilderFactory.newInstance();
 		fac.setNamespaceAware(true);
-		MockMvcBuilders.webAppContextSetup(this.wac).build();
-		WPSConfig.getInstance().setConfigurationManager(this.wac.getBean(ConfigurationManager.class));
+        RepositoryManager repositoryManager = new RepositoryManager();
+        repositoryManager.setApplicationContext(wac);
+        repositoryManager.init();
 	}
 
 	@Test

--- a/52n-wps-server/src/test/java/org/n52/wps/server/response/OutputDataItemTest.java
+++ b/52n-wps-server/src/test/java/org/n52/wps/server/response/OutputDataItemTest.java
@@ -78,12 +78,12 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 /**
  * @author BenjaminPross(bpross-52n)
- * 
+ *
  * This class is for testing the updateResponseForLiteralData() method of the class OutputDataItem.java.
  *
  */
 public class OutputDataItemTest extends AbstractITClass{
-	
+
 	private ProcessDescriptionType descriptionsType;
 	private ProcessDescription description;
 	private String processID = "org.n52.wps.server.response.OutputDataItemTest";
@@ -97,9 +97,6 @@ public class OutputDataItemTest extends AbstractITClass{
 
 	@Before
 	public void setUp() {
-		MockMvcBuilders.webAppContextSetup(this.wac).build();
-		WPSConfig.getInstance().setConfigurationManager(this.wac.getBean(ConfigurationManager.class));
-
 		literalDataList = new ArrayList<ILiteralData>();
 
 		String url = "";
@@ -111,7 +108,7 @@ public class OutputDataItemTest extends AbstractITClass{
 		}
 
 		String uuid = UUID.randomUUID().toString();
-		
+
 		literalDataList.add(new LiteralBase64BinaryBinding(uuid.getBytes()));
 		literalDataList.add(new LiteralBooleanBinding(true));
 		literalDataList.add(new LiteralByteBinding((byte) 127));
@@ -205,7 +202,7 @@ public class OutputDataItemTest extends AbstractITClass{
 						.concat((int) bytes[i] + ", ");
 				}else{
 					bytesAsIntegerValues = bytesAsIntegerValues
-							.concat((int) bytes[i] + "]");					
+							.concat((int) bytes[i] + "]");
 				}
 			}
 			startText = startText.concat("" + bytesAsIntegerValues);
@@ -228,9 +225,9 @@ public class OutputDataItemTest extends AbstractITClass{
 		outputType.addNewDataType().setStringValue(dataTypeAsString);
 
 		description = new ProcessDescription();
-		
+
 		description.addProcessDescriptionForVersion(descriptionsType, WPSConfig.VERSION_100);
-		
+
 		OutputDataItem ouDI = new OutputDataItem(literalDataBinding, "output",
 				null, null, null, outputTitle, processID, description);
 

--- a/52n-wps-server/src/test/java/org/n52/wps/server/response/RawDataTest.java
+++ b/52n-wps-server/src/test/java/org/n52/wps/server/response/RawDataTest.java
@@ -65,8 +65,6 @@ public class RawDataTest  extends AbstractITClass{
 
     @Before
     public void setUp(){
-		MockMvcBuilders.webAppContextSetup(this.wac).build();
-		WPSConfig.getInstance().setConfigurationManager(this.wac.getBean(ConfigurationManager.class));
     	algorithm = new DummyTestClass();
     	processDescription = algorithm.getDescription();
     	identifier = algorithm.getWellKnownName();

--- a/52n-wps-server/src/test/java/org/n52/wps/server/response/StatusTest.java
+++ b/52n-wps-server/src/test/java/org/n52/wps/server/response/StatusTest.java
@@ -58,6 +58,7 @@ import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 import static org.junit.Assert.assertTrue;
+import org.n52.wps.server.RepositoryManagerSingletonWrapper;
 
 public class StatusTest extends AbstractITClass {
 
@@ -67,11 +68,13 @@ public class StatusTest extends AbstractITClass {
 
     @Before
     public void setUp() {
-        MockMvcBuilders.webAppContextSetup(this.wac).build();
-        WPSConfig.getInstance().setConfigurationManager(this.wac.getBean(ConfigurationManager.class));
         fac = DocumentBuilderFactory.newInstance();
         fac.setNamespaceAware(true);
         algorithm = new StatusTestingProcess();
+
+        RepositoryManager repositoryManager = new RepositoryManager();
+        repositoryManager.setApplicationContext(wac);
+        repositoryManager.init();
     }
 
     @Test
@@ -87,7 +90,7 @@ public class StatusTest extends AbstractITClass {
 
             final String requestID = executeRequestV200.getUniqueId().toString();
 
-            algorithm = RepositoryManager.getInstance().getAlgorithm(executeRequestV200.getAlgorithmIdentifier());
+            algorithm = RepositoryManagerSingletonWrapper.getInstance().getAlgorithm(executeRequestV200.getAlgorithmIdentifier());
 
             if (algorithm instanceof ISubject) {
                 ISubject subject = (ISubject) algorithm;
@@ -98,7 +101,7 @@ public class StatusTest extends AbstractITClass {
                         try {
                             StatusInfoDocument statusInfoDocument = StatusInfoDocument.Factory.parse(DatabaseFactory.getDatabase().lookupStatus(requestID));
                             assertTrue(statusInfoDocument.getStatusInfo().getStatus() != null);
-                            
+
                         } catch (ExceptionReport | XmlException | IOException e) {
                             e.printStackTrace();
                         }

--- a/52n-wps-webapp/src/main/resources/db/initial-data.sql
+++ b/52n-wps-webapp/src/main/resources/db/initial-data.sql
@@ -19,6 +19,7 @@ INSERT INTO ALGORITHMENTRY VALUES('test.echo','org.n52.wps.server.r.RConfigurati
 INSERT INTO ALGORITHMENTRY VALUES('test.calculator','org.n52.wps.server.r.RConfigurationModule',TRUE);
 INSERT INTO ALGORITHMENTRY VALUES('test.metadata','org.n52.wps.server.r.RConfigurationModule',TRUE);
 INSERT INTO ALGORITHMENTRY VALUES('test.geo','org.n52.wps.server.r.RConfigurationModule',TRUE);
+INSERT INTO ALGORITHMENTRY VALUES('test.image','org.n52.wps.server.r.RConfigurationModule',TRUE);
 INSERT INTO ALGORITHMENTRY VALUES('test.wpsOff','org.n52.wps.server.r.RConfigurationModule',TRUE);
 INSERT INTO ALGORITHMENTRY VALUES('test.session','org.n52.wps.server.r.RConfigurationModule',TRUE);
 INSERT INTO ALGORITHMENTRY VALUES('geo.poly.attribute-sum','org.n52.wps.server.r.RConfigurationModule',TRUE);
@@ -661,7 +662,7 @@ INSERT INTO FORMATENTRY VALUES('application/x-geotiff', '', 'base64', 'org.n52.w
 INSERT INTO FORMATENTRY VALUES('application/hdf4-eos', '', 'base64', 'org.n52.wps.io.modules.parser.GenericRasterFileParserCM', TRUE);
 INSERT INTO FORMATENTRY VALUES('text/plain', '', 'base64', 'org.n52.wps.io.modules.parser.GenericRasterFileParserCM', TRUE);
 INSERT INTO FORMATENTRY VALUES('application/img', '', '', 'org.n52.wps.io.modules.parser.GenericRasterFileParserCM', TRUE);
-INSERT INTO FORMATENTRY VALUES('image/tiff', '', '', 'org.n52.wps.io.modules.parser.GenericRasterFileParserCM', TRUE); 
+INSERT INTO FORMATENTRY VALUES('image/tiff', '', '', 'org.n52.wps.io.modules.parser.GenericRasterFileParserCM', TRUE);
 INSERT INTO FORMATENTRY VALUES('image/geotiff', '', '', 'org.n52.wps.io.modules.parser.GenericRasterFileParserCM', TRUE);
 INSERT INTO FORMATENTRY VALUES('application/geotiff', '', '', 'org.n52.wps.io.modules.parser.GenericRasterFileParserCM', TRUE);
 INSERT INTO FORMATENTRY VALUES('application/dbase', '', '', 'org.n52.wps.io.modules.parser.GenericRasterFileParserCM', TRUE);

--- a/52n-wps-webapp/src/main/resources/dispatcher-servlet.xml
+++ b/52n-wps-webapp/src/main/resources/dispatcher-servlet.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd 
+http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
 
 	<mvc:annotation-driven />
@@ -13,6 +13,8 @@ http://www.springframework.org/schema/mvc http://www.springframework.org/schema/
 	<mvc:resources mapping="/static/**" location="/static/" />
 
     <bean id="webProcessingService" class="org.n52.wps.server.WebProcessingService" init-method="init" />
+
+    <bean id="repositoryManager" class="org.n52.wps.server.RepositoryManager" scope="singleton" />
 
 	<!-- landing page and admin web application -->
 <!-- 	<bean id="viewResolver" -->
@@ -37,7 +39,7 @@ http://www.springframework.org/schema/mvc http://www.springframework.org/schema/
 	<bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
 		<property name="maxUploadSize" value="1000000" />
 	</bean>
-	
+
 	<beans profile="production">
 		<context:component-scan base-package="org.n52.wps">
 			<context:include-filter type="assignable" expression="org.n52.wps.webapp.api.ConfigurationModule" />

--- a/52n-wps-webapp/src/main/webapp/WEB-INF/spring-mvc-config.xml
+++ b/52n-wps-webapp/src/main/webapp/WEB-INF/spring-mvc-config.xml
@@ -15,7 +15,7 @@
 	<mvc:view-controller path="/" view-name="index" />
 
 	<bean id="webProcessingServiceController" class="org.n52.wps.server.WebProcessingServiceController" init-method="init" destroy-method="destroy"/>
-	
+
 <!-- 	<bean id="jdbcConfigurationDao" class="org.n52.wps.webapp.dao.JdbcConfigurationDAO" init-method="init"/> -->
 
 	<!-- Apache Tiles 3 -->

--- a/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/GeneratorsControllerIntegrationTest.java
+++ b/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/GeneratorsControllerIntegrationTest.java
@@ -57,7 +57,6 @@ public class GeneratorsControllerIntegrationTest extends AbstractITClassForContr
 
 	@Before
 	public void setup() {
-		mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
 	}
 
 	@Test

--- a/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/LogConfigurationsControllerIntegrationTest.java
+++ b/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/LogConfigurationsControllerIntegrationTest.java
@@ -57,16 +57,15 @@ public class LogConfigurationsControllerIntegrationTest extends AbstractITClassF
 
 	@Autowired
 	ConfigurationManager configurationManager;
-	
+
 	@Autowired
 	private JDomUtil jDomUtil;
-	
+
 	@Autowired
 	private ResourcePathUtil resourcePathUtil;
-	
+
 	@Before
 	public void setup() {
-		mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
 	}
 
 	@Test
@@ -81,7 +80,7 @@ public class LogConfigurationsControllerIntegrationTest extends AbstractITClassF
 	public void processPost_success() throws Exception {
 		String path = resourcePathUtil.getClassPathResourcePath(XmlLogConfigurationsDAO.FILE_NAME);
 		Document originalDoc = jDomUtil.parse(path);
-		
+
 		RequestBuilder request = post("/log")
 				.param("wpsfileAppenderFileNamePattern", "testFileAppenderFileNamePattern")
 		.param("wpsfileAppenderEncoderPattern", "testFileAppenderFileNamePattern")
@@ -96,7 +95,7 @@ public class LogConfigurationsControllerIntegrationTest extends AbstractITClassF
 		result.andExpect(status().isOk());
 		LogConfigurations logConfigurations = configurationManager.getLogConfigurationsServices().getLogConfigurations();
 		assertEquals("testFileAppenderFileNamePattern", logConfigurations.getWpsfileAppenderFileNamePattern());
-		
+
 		//reset document to original state
 		jDomUtil.write(originalDoc, path);
 	}

--- a/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/ParsersControllerIntegrationTest.java
+++ b/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/ParsersControllerIntegrationTest.java
@@ -57,7 +57,6 @@ public class ParsersControllerIntegrationTest extends AbstractITClassForControll
 
 	@Before
 	public void setup() {
-		mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
 	}
 
 	@Test

--- a/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/RepositoriesControllerIntegrationTest.java
+++ b/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/RepositoriesControllerIntegrationTest.java
@@ -57,7 +57,6 @@ public class RepositoriesControllerIntegrationTest extends AbstractITClassForCon
 
 	@Before
 	public void setup() {
-		mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
 	}
 
 	@Test

--- a/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/ServerControllerIntegrationTest.java
+++ b/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/ServerControllerIntegrationTest.java
@@ -52,10 +52,9 @@ public class ServerControllerIntegrationTest extends AbstractITClassForControlle
 
 	@Autowired
 	private Server server;
-	
+
 	@Before
 	public void setup() {
-		mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
 	}
 
 	@Test

--- a/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/ServiceIdentificationControllerIntegrationTest.java
+++ b/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/ServiceIdentificationControllerIntegrationTest.java
@@ -54,19 +54,18 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 public class ServiceIdentificationControllerIntegrationTest extends AbstractITClassForControllerTests {
 
 	private MockMvc mockMvc;
-	
+
 	@Autowired
 	ConfigurationManager configurationManager;
-	
+
 	@Autowired
 	private JDomUtil jDomUtil;
-	
+
 	@Autowired
 	private ResourcePathUtil resourcePathUtil;
 
 	@Before
 	public void setup() {
-		mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
 	}
 
 	@Test
@@ -81,7 +80,7 @@ public class ServiceIdentificationControllerIntegrationTest extends AbstractITCl
 	public void processPost_success() throws Exception {
 		String path = resourcePathUtil.getWebAppResourcePath(XmlCapabilitiesDAO.FILE_NAME);
 		Document originalDoc = jDomUtil.parse(path);
-		
+
 		RequestBuilder request = post("/service_identification")
 				.param("title", "Posted Title")
 				.param("serviceAbstract", "Posted Service Abstract")
@@ -94,7 +93,7 @@ public class ServiceIdentificationControllerIntegrationTest extends AbstractITCl
 		result.andExpect(status().isOk());
 		ServiceIdentification serviceIdentification = configurationManager.getCapabilitiesServices().getServiceIdentification();
 		assertEquals("Posted Title", serviceIdentification.getTitle());
-		
+
 		//reset document to original state
 		jDomUtil.write(originalDoc, path);
 	}

--- a/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/ServiceProviderControllerIntegrationTest.java
+++ b/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/ServiceProviderControllerIntegrationTest.java
@@ -57,16 +57,15 @@ public class ServiceProviderControllerIntegrationTest extends AbstractITClassFor
 
 	@Autowired
 	private ConfigurationManager configurationManager;
-	
+
 	@Autowired
 	private JDomUtil jDomUtil;
-	
+
 	@Autowired
 	private ResourcePathUtil resourcePathUtil;
-	
+
 	@Before
 	public void setup() {
-		mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
 	}
 
 	@Test
@@ -81,7 +80,7 @@ public class ServiceProviderControllerIntegrationTest extends AbstractITClassFor
 	public void processPost_success() throws Exception {
 		String path = resourcePathUtil.getWebAppResourcePath(XmlCapabilitiesDAO.FILE_NAME);
 		Document originalDoc = jDomUtil.parse(path);
-		
+
 		RequestBuilder request = post("/service_provider")
 				.param("providerName", "providerName")
 				.param("providerSite", "providerSite")
@@ -99,12 +98,12 @@ public class ServiceProviderControllerIntegrationTest extends AbstractITClassFor
 		result.andExpect(status().isOk());
 		ServiceProvider serviceProvider = configurationManager.getCapabilitiesServices().getServiceProvider();
 		assertEquals("providerName", serviceProvider.getProviderName());
-		
+
 		//reset document to original state
 		jDomUtil.write(originalDoc, path);
 	}
 
-	//not needed anymore in this form, as all provider parameters are optional now 
+	//not needed anymore in this form, as all provider parameters are optional now
 //	@Test
 //	public void processPost_failure() throws Exception {
 //		RequestBuilder request = post("/service_provider")

--- a/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/UploadControllerIntegrationTest.java
+++ b/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/UploadControllerIntegrationTest.java
@@ -72,7 +72,6 @@ public class UploadControllerIntegrationTest extends AbstractITClassForControlle
 
 	@Before
 	public void setup() {
-		mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
 	}
 
 	@Test

--- a/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/UsersControllerIntegrationTest.java
+++ b/52n-wps-webapp/src/test/java/org/n52/wps/webapp/web/UsersControllerIntegrationTest.java
@@ -61,7 +61,6 @@ public class UsersControllerIntegrationTest extends AbstractITClassForController
 
 	@Before
 	public void setup() {
-		mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
 	}
 
 	@Test


### PR DESCRIPTION
Adds a thin abstraction tier to remove Singleton pattern from `RepositoryManager`. This was needed to be managable by IoC. Would fix #195 