### PR TITLE
Use newer BeanShell 2.0b6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -748,9 +748,9 @@
 				<version>1.0.1</version>
 			</dependency>
 			<dependency>
-				<groupId>org.beanshell</groupId>
+				<groupId>org.apache-extras.beanshell</groupId>
 				<artifactId>bsh</artifactId>
-				<version>2.0b4</version>
+				<version>2.0b6</version>
 			</dependency>
 			<dependency>
 				<groupId>jfree</groupId>


### PR DESCRIPTION
This fixes the possibly remote code execution security vulnerability [CVE-2016-2510](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-2510)

See https://github.com/beanshell/beanshell/releases/tag/2.0b6 for details.

(2.0b6 should be backwards compatible with 2.0b4 - however it is released under the Apache License 2.0 - see NOTICE and LICENSE at https://github.com/beanshell/beanshell)