### PR TITLE
Update maven repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,15 +59,26 @@
             </snapshots>
         </repository>
         <repository>
-            <id>geotools</id>
-            <name>Geotools Repo</name>
-            <url>http://download.osgeo.org/webdav/geotools</url>
+            <id>osgeo</id>
+            <name>OSGeo Release Repository</name>
+            <url>https://repo.osgeo.org/repository/release/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
             <releases>
                 <enabled>true</enabled>
             </releases>
+        </repository>
+        <repository>
+            <id>osgeo-snapshot</id>
+            <name>OSGeo Snapshot Repository</name>
+            <url>https://repo.osgeo.org/repository/snapshot/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
     </repositories>
     <build>


### PR DESCRIPTION
The GeoTools Maven repositories had changed so the build fails with:
```
[ERROR] Non-resolvable import POM: Could not find artifact org.geotools:geotools:pom:13.5 in n52-releases (http://52north.org/maven/repo/releases) @ line 321, column 25
```
Please have a look at my solution to fix this error.